### PR TITLE
fix: improve folder detection to support dots in folder names

### DIFF
--- a/src/pathfilter.test.ts
+++ b/src/pathfilter.test.ts
@@ -268,5 +268,17 @@ describe("PathFilter", () => {
       expect(filter.isAllowed("folder/subfolder/")).toBe(true);
       expect(filter.isAllowed("notes")).toBe(true);
     });
+
+    test("handles directories with dots in their names", () => {
+      const filter = new PathFilter();
+      // Folders with dots should be allowed (common pattern: "1. Project", "2.5 Notes")
+      expect(filter.isAllowed("1. Project")).toBe(true);
+      expect(filter.isAllowed("2. Archive")).toBe(true);
+      expect(filter.isAllowed("3.5 Research")).toBe(true);
+      expect(filter.isAllowed("1. Project/subfolder")).toBe(true);
+      expect(filter.isAllowed("1. Project/note.md")).toBe(true);
+      // But files in those folders should still need proper extensions
+      expect(filter.isAllowed("1. Project/file.js")).toBe(false);
+    });
   });
 });

--- a/src/pathfilter.ts
+++ b/src/pathfilter.ts
@@ -65,7 +65,29 @@ export class PathFilter {
   }
 
   private isFile(path: string): boolean {
-    return path.includes('.') && !path.endsWith('/');
+    // A path is a file if it has a file extension at the end
+    // Paths ending with '/' are always directories
+    if (path.endsWith('/')) {
+      return false;
+    }
+
+    // Get the last component of the path
+    const lastSlashIndex = path.lastIndexOf('/');
+    const lastComponent = lastSlashIndex === -1 ? path : path.substring(lastSlashIndex + 1);
+
+    // Check if the last component has a file extension
+    // A file extension is a dot followed by 1-10 alphanumeric characters at the end
+    // This distinguishes "file.md" (file) from "1. Project" (directory with dot in name)
+    const lastDotIndex = lastComponent.lastIndexOf('.');
+    if (lastDotIndex === -1 || lastDotIndex === 0) {
+      // No dot, or dot at the start (like .gitignore) - treat as no extension
+      return false;
+    }
+
+    const extension = lastComponent.substring(lastDotIndex + 1);
+    // Extension should be 1-10 characters and contain only alphanumeric characters
+    // This allows .md, .txt, .markdown but not ". Project" (space after dot)
+    return extension.length >= 1 && extension.length <= 10 && /^[a-zA-Z0-9]+$/.test(extension);
   }
 
   filterPaths(paths: string[]): string[] {


### PR DESCRIPTION
Folders with dots in their names (e.g., "1. Project", "2.5 Notes") were incorrectly being filtered out by the PathFilter. The isFile() method was too simplistic, treating any path component with a dot as a file.

Changes:
- Enhanced isFile() to check for valid file extensions (1-10 alphanumeric characters after the last dot) instead of just checking for any dot
- This allows folders like "1. Project" to be recognized as directories
- Files still require proper extensions (.md, .txt, .markdown)
- Added comprehensive test coverage for this edge case

Fixes issue where users couldn't access folders with numeric prefixes followed by dots and spaces.