### PR TITLE
feat: add read_base tool for querying Obsidian Bases

### DIFF
--- a/dist/src/bases.js
+++ b/dist/src/bases.js
@@ -1,0 +1,224 @@
+import { join, resolve, relative } from 'path';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { parse as parseYaml } from 'yaml';
+import { FilterParser } from './filter-parser.js';
+export class BasesService {
+    vaultPath;
+    pathFilter;
+    frontmatterHandler;
+    filterParser;
+    constructor(vaultPath, pathFilter, frontmatterHandler) {
+        this.vaultPath = vaultPath;
+        this.pathFilter = pathFilter;
+        this.frontmatterHandler = frontmatterHandler;
+        this.vaultPath = resolve(vaultPath);
+        this.filterParser = new FilterParser();
+    }
+    async readBase(basePath) {
+        const fullPath = this.resolvePath(basePath);
+        if (!basePath.endsWith('.base')) {
+            throw new Error(`Not a base file: ${basePath}`);
+        }
+        const content = await readFile(fullPath, 'utf-8');
+        const parsed = parseYaml(content);
+        return parsed || { views: [] };
+    }
+    async queryBase(params) {
+        const { path: basePath, view: viewName, limit, includeFrontmatter } = params;
+        const base = await this.readBase(basePath);
+        const availableViews = base.views?.map(v => v.name) || [];
+        const allWarnings = [];
+        let targetView;
+        if (viewName) {
+            targetView = base.views?.find(v => v.name === viewName);
+            if (!targetView) {
+                throw new Error(`View "${viewName}" not found. Available views: ${availableViews.join(', ') || 'none'}`);
+            }
+        }
+        const allNotes = await this.getAllNoteContexts();
+        let matchingNotes = allNotes.filter(note => {
+            const result = this.filterParser.evaluateFilterGroup(base.filters, note);
+            allWarnings.push(...result.warnings);
+            return result.matches;
+        });
+        let filtersApplied = this.countFilters(base.filters);
+        if (targetView?.filters) {
+            matchingNotes = matchingNotes.filter(note => {
+                const result = this.filterParser.evaluateFilterGroup(targetView.filters, note);
+                allWarnings.push(...result.warnings);
+                return result.matches;
+            });
+            filtersApplied += this.countFilters(targetView.filters);
+        }
+        if (targetView?.sort) {
+            matchingNotes = this.sortNotes(matchingNotes, targetView.sort);
+        }
+        const effectiveLimit = Math.min(limit ?? targetView?.limit ?? 50, 100);
+        matchingNotes = matchingNotes.slice(0, effectiveLimit);
+        const notes = matchingNotes.map(note => {
+            const result = {
+                p: note.filePath,
+                t: note.fileName.replace(/\.md$/, '')
+            };
+            if (includeFrontmatter) {
+                result.fm = note.frontmatter;
+            }
+            return result;
+        });
+        const uniqueWarnings = [...new Set(allWarnings)];
+        const result = {
+            notes,
+            views: availableViews,
+            q: {
+                view: viewName || null,
+                limit: effectiveLimit,
+                filters: filtersApplied
+            }
+        };
+        if (uniqueWarnings.length > 0) {
+            result.w = uniqueWarnings;
+        }
+        return result;
+    }
+    async getAllNoteContexts() {
+        const markdownFiles = await this.findMarkdownFiles(this.vaultPath);
+        const contexts = [];
+        for (const fullPath of markdownFiles) {
+            const relativePath = fullPath.substring(this.vaultPath.length + 1).replace(/\\/g, '/');
+            if (!this.pathFilter.isAllowed(relativePath))
+                continue;
+            if (relativePath.endsWith('.base'))
+                continue;
+            try {
+                const content = await readFile(fullPath, 'utf-8');
+                const stats = await stat(fullPath);
+                const parsed = this.frontmatterHandler.parse(content);
+                const tags = this.extractTags(parsed.frontmatter, parsed.content);
+                const fileName = relativePath.split('/').pop() || relativePath;
+                contexts.push({
+                    filePath: relativePath,
+                    fileName,
+                    frontmatter: parsed.frontmatter,
+                    content: parsed.content,
+                    ctime: stats.birthtime,
+                    mtime: stats.mtime,
+                    tags
+                });
+            }
+            catch {
+                continue;
+            }
+        }
+        return contexts;
+    }
+    extractTags(frontmatter, content) {
+        const tags = [];
+        if (frontmatter.tags) {
+            if (Array.isArray(frontmatter.tags)) {
+                for (const t of frontmatter.tags) {
+                    if (typeof t === 'string') {
+                        tags.push(t);
+                    }
+                }
+            }
+            else if (typeof frontmatter.tags === 'string') {
+                tags.push(frontmatter.tags);
+            }
+        }
+        const inlineMatches = content.match(/#[a-zA-Z0-9_\-/]+/g) || [];
+        const inlineTags = inlineMatches.map(tag => tag.slice(1));
+        tags.push(...inlineTags);
+        return [...new Set(tags)];
+    }
+    sortNotes(notes, sorts) {
+        return [...notes].sort((a, b) => {
+            for (const sort of sorts) {
+                const aVal = this.getSortValue(a, sort.property);
+                const bVal = this.getSortValue(b, sort.property);
+                const cmp = this.compareValues(aVal, bVal);
+                if (cmp !== 0) {
+                    return sort.direction === 'DESC' ? -cmp : cmp;
+                }
+            }
+            return 0;
+        });
+    }
+    getSortValue(note, prop) {
+        if (prop.startsWith('file.')) {
+            const field = prop.slice(5);
+            switch (field) {
+                case 'name': return note.fileName;
+                case 'path': return note.filePath;
+                case 'ctime': return note.ctime;
+                case 'mtime': return note.mtime;
+            }
+        }
+        if (prop.startsWith('property.')) {
+            return note.frontmatter[prop.slice(9)];
+        }
+        return note.frontmatter[prop];
+    }
+    compareValues(a, b) {
+        if (a === undefined && b === undefined)
+            return 0;
+        if (a === undefined)
+            return 1;
+        if (b === undefined)
+            return -1;
+        if (a instanceof Date && b instanceof Date) {
+            return a.getTime() - b.getTime();
+        }
+        if (typeof a === 'number' && typeof b === 'number') {
+            return a - b;
+        }
+        return String(a).localeCompare(String(b));
+    }
+    countFilters(group) {
+        if (!group)
+            return 0;
+        let count = 0;
+        const items = group.and || group.or || [];
+        for (const item of items) {
+            if (typeof item === 'string') {
+                count++;
+            }
+            else {
+                count += this.countFilters(item);
+            }
+        }
+        return count;
+    }
+    async findMarkdownFiles(dirPath) {
+        const files = [];
+        try {
+            const entries = await readdir(dirPath, { withFileTypes: true });
+            for (const entry of entries) {
+                const fullPath = join(dirPath, entry.name);
+                if (entry.isDirectory()) {
+                    if (entry.name.startsWith('.') || entry.name === 'node_modules') {
+                        continue;
+                    }
+                    const subFiles = await this.findMarkdownFiles(fullPath);
+                    files.push(...subFiles);
+                }
+                else if (entry.isFile() && entry.name.endsWith('.md')) {
+                    files.push(fullPath);
+                }
+            }
+        }
+        catch {
+        }
+        return files;
+    }
+    resolvePath(relativePath) {
+        const normalizedPath = relativePath.startsWith('/')
+            ? relativePath.slice(1)
+            : relativePath;
+        const fullPath = resolve(join(this.vaultPath, normalizedPath));
+        const relativeToVault = relative(this.vaultPath, fullPath);
+        if (relativeToVault.startsWith('..')) {
+            throw new Error(`Path traversal not allowed: ${relativePath}`);
+        }
+        return fullPath;
+    }
+}

--- a/dist/src/bases.test.js
+++ b/dist/src/bases.test.js
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { FilterParser } from './filter-parser.js';
+describe('FilterParser', () => {
+    let parser;
+    let baseContext;
+    beforeEach(() => {
+        parser = new FilterParser();
+        baseContext = {
+            filePath: 'Notes/test-note.md',
+            fileName: 'test-note.md',
+            frontmatter: {
+                tags: ['llms', 'ai/prompts'],
+                type: 'Book',
+                status: 'active',
+                author: 'John Doe',
+                date: '2025-01-01',
+                source: 'https://github.com/example/repo'
+            },
+            content: 'Some content with #inline-tag and #another/nested',
+            ctime: new Date('2025-01-01'),
+            mtime: new Date('2025-01-05'),
+            tags: ['llms', 'ai/prompts', 'inline-tag', 'another/nested']
+        };
+    });
+    describe('file.hasTag', () => {
+        it('matches exact tag', () => {
+            const result = parser.evaluateFilterGroup({ and: ['file.hasTag("llms")'] }, baseContext);
+            expect(result.matches).toBe(true);
+            expect(result.warnings).toHaveLength(0);
+        });
+        it('matches tag with hash prefix in expression', () => {
+            const result = parser.evaluateFilterGroup({ and: ['file.hasTag("#llms")'] }, baseContext);
+            expect(result.matches).toBe(true);
+        });
+        it('returns false for missing tag', () => {
+            const result = parser.evaluateFilterGroup({ and: ['file.hasTag("nonexistent")'] }, baseContext);
+            expect(result.matches).toBe(false);
+        });
+    });
+    describe('tags.contains', () => {
+        it('matches substring in tag', () => {
+            const result = parser.evaluateFilterGroup({ and: ['tags.contains("ai/prompts")'] }, baseContext);
+            expect(result.matches).toBe(true);
+        });
+        it('matches partial tag path', () => {
+            const result = parser.evaluateFilterGroup({ and: ['tags.contains("ai/")'] }, baseContext);
+            expect(result.matches).toBe(true);
+        });
+        it('matches inline tags', () => {
+            const result = parser.evaluateFilterGroup({ and: ['tags.contains("inline-tag")'] }, baseContext);
+            expect(result.matches).toBe(true);
+        });
+    });
+    describe('file.path.startsWith', () => {
+        it('matches path prefix', () => {
+            const result = parser.evaluateFilterGroup({ and: ['file.path.startsWith("Notes/")'] }, baseContext);
+            expect(result.matches).toBe(true);
+        });
+        it('returns false for non-matching prefix', () => {
+            const result = parser.evaluateFilterGroup({ and: ['file.path.startsWith("Other/")'] }, baseContext);
+            expect(result.matches).toBe(false);
+        });
+    });
+    describe('property equality', () => {
+        it('matches string property', () => {
+            const result = parser.evaluateFilterGroup({ and: ['type == "Book"'] }, baseContext);
+            expect(result.matches).toBe(true);
+        });
+        it('handles inequality', () => {
+            const result = parser.evaluateFilterGroup({ and: ['status != "archived"'] }, baseContext);
+            expect(result.matches).toBe(true);
+        });
+        it('returns false for non-matching value', () => {
+            const result = parser.evaluateFilterGroup({ and: ['type == "Movie"'] }, baseContext);
+            expect(result.matches).toBe(false);
+        });
+    });
+    describe('property.contains', () => {
+        it('matches string property containing substring', () => {
+            const result = parser.evaluateFilterGroup({ and: ['source.contains("github")'] }, baseContext);
+            expect(result.matches).toBe(true);
+        });
+        it('returns false for non-matching substring', () => {
+            const result = parser.evaluateFilterGroup({ and: ['source.contains("gitlab")'] }, baseContext);
+            expect(result.matches).toBe(false);
+        });
+    });
+    describe('property.containsAny', () => {
+        it('matches any of multiple substrings', () => {
+            const result = parser.evaluateFilterGroup({ and: ['source.containsAny("gitlab", "github")'] }, baseContext);
+            expect(result.matches).toBe(true);
+        });
+        it('returns false when none match', () => {
+            const result = parser.evaluateFilterGroup({ and: ['source.containsAny("gitlab", "bitbucket")'] }, baseContext);
+            expect(result.matches).toBe(false);
+        });
+    });
+    describe('property.isEmpty', () => {
+        it('returns true for undefined property', () => {
+            const result = parser.evaluateFilterGroup({ and: ['updated.isEmpty()'] }, baseContext);
+            expect(result.matches).toBe(true);
+        });
+        it('returns false for existing property', () => {
+            const result = parser.evaluateFilterGroup({ and: ['type.isEmpty()'] }, baseContext);
+            expect(result.matches).toBe(false);
+        });
+    });
+    describe('date comparisons', () => {
+        it('handles file.ctime comparison with today()', () => {
+            const recentContext = {
+                ...baseContext,
+                ctime: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000)
+            };
+            const result = parser.evaluateFilterGroup({ and: ['file.ctime > today() - "7d"'] }, recentContext);
+            expect(result.matches).toBe(true);
+        });
+        it('handles file.mtime comparison', () => {
+            const recentContext = {
+                ...baseContext,
+                mtime: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000)
+            };
+            const result = parser.evaluateFilterGroup({ and: ['file.mtime > today() - "7d"'] }, recentContext);
+            expect(result.matches).toBe(true);
+        });
+        it('handles frontmatter date property comparison', () => {
+            const recentContext = {
+                ...baseContext,
+                frontmatter: {
+                    ...baseContext.frontmatter,
+                    date: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString()
+                }
+            };
+            const result = parser.evaluateFilterGroup({ and: ['date > today() - "7d"'] }, recentContext);
+            expect(result.matches).toBe(true);
+        });
+    });
+    describe('logical operators', () => {
+        it('handles AND with all matching', () => {
+            const result = parser.evaluateFilterGroup({ and: ['type == "Book"', 'file.hasTag("llms")'] }, baseContext);
+            expect(result.matches).toBe(true);
+        });
+        it('handles AND with one not matching', () => {
+            const result = parser.evaluateFilterGroup({ and: ['type == "Book"', 'type == "Movie"'] }, baseContext);
+            expect(result.matches).toBe(false);
+        });
+        it('handles OR with one matching', () => {
+            const result = parser.evaluateFilterGroup({ or: ['type == "Book"', 'type == "Movie"'] }, baseContext);
+            expect(result.matches).toBe(true);
+        });
+        it('handles OR with none matching', () => {
+            const result = parser.evaluateFilterGroup({ or: ['type == "Movie"', 'type == "Show"'] }, baseContext);
+            expect(result.matches).toBe(false);
+        });
+        it('handles nested groups', () => {
+            const group = {
+                and: [
+                    'type == "Book"',
+                    { or: ['status == "active"', 'status == "pending"'] }
+                ]
+            };
+            const result = parser.evaluateFilterGroup(group, baseContext);
+            expect(result.matches).toBe(true);
+        });
+    });
+    describe('unsupported expressions', () => {
+        it('returns warning and matches for unsupported syntax', () => {
+            const result = parser.evaluateFilterGroup({ and: ['author.contains(link("Dylan Shade", "dpshade"))'] }, baseContext);
+            expect(result.matches).toBe(true);
+            expect(result.warnings).toHaveLength(1);
+            expect(result.warnings[0]).toContain('Unsupported filter');
+        });
+    });
+    describe('empty/undefined filters', () => {
+        it('returns true for undefined filter group', () => {
+            const result = parser.evaluateFilterGroup(undefined, baseContext);
+            expect(result.matches).toBe(true);
+        });
+        it('returns true for empty filter group', () => {
+            const result = parser.evaluateFilterGroup({}, baseContext);
+            expect(result.matches).toBe(true);
+        });
+    });
+});

--- a/dist/src/filter-parser.js
+++ b/dist/src/filter-parser.js
@@ -1,0 +1,212 @@
+export class FilterParser {
+    warnings = [];
+    evaluateFilterGroup(group, ctx) {
+        this.warnings = [];
+        if (!group) {
+            return { matches: true, warnings: [] };
+        }
+        const matches = this.evalGroup(group, ctx);
+        return { matches, warnings: this.warnings };
+    }
+    evalGroup(group, ctx) {
+        if (group.and) {
+            return group.and.every(item => this.evalItem(item, ctx));
+        }
+        if (group.or) {
+            return group.or.some(item => this.evalItem(item, ctx));
+        }
+        return true;
+    }
+    evalItem(item, ctx) {
+        if (typeof item === 'string') {
+            return this.evalExpression(item, ctx);
+        }
+        return this.evalGroup(item, ctx);
+    }
+    evalExpression(expr, ctx) {
+        const trimmed = expr.trim();
+        // file.hasTag("x")
+        const hasTagMatch = trimmed.match(/^file\.hasTag\(["'](.+?)["']\)$/);
+        if (hasTagMatch && hasTagMatch[1]) {
+            return this.hasTag(ctx, hasTagMatch[1]);
+        }
+        // tags.contains("x") or file.tags.contains("x")
+        const tagsContainsMatch = trimmed.match(/^(?:file\.)?tags\.contains\(["'](.+?)["']\)$/);
+        if (tagsContainsMatch && tagsContainsMatch[1]) {
+            return this.tagsContains(ctx, tagsContainsMatch[1]);
+        }
+        // file.path.startsWith("x")
+        const pathStartsMatch = trimmed.match(/^file\.path\.startsWith\(["'](.+?)["']\)$/);
+        if (pathStartsMatch && pathStartsMatch[1]) {
+            return ctx.filePath.startsWith(pathStartsMatch[1]);
+        }
+        // property.startsWith("x")
+        const propStartsMatch = trimmed.match(/^(\w+)\.startsWith\(["'](.+?)["']\)$/);
+        if (propStartsMatch && propStartsMatch[1] && propStartsMatch[2] && propStartsMatch[1] !== 'file') {
+            const val = ctx.frontmatter[propStartsMatch[1]];
+            return typeof val === 'string' && val.startsWith(propStartsMatch[2]);
+        }
+        // property.contains("x")
+        const propContainsMatch = trimmed.match(/^(\w+)\.contains\(["'](.+?)["']\)$/);
+        if (propContainsMatch && propContainsMatch[1] && propContainsMatch[2]) {
+            return this.propertyContains(ctx, propContainsMatch[1], propContainsMatch[2]);
+        }
+        // property.containsAny("x", "y", ...)
+        const containsAnyMatch = trimmed.match(/^(\w+)\.containsAny\((.+)\)$/);
+        if (containsAnyMatch && containsAnyMatch[1] && containsAnyMatch[2]) {
+            const values = this.parseStringArgs(containsAnyMatch[2]);
+            return this.propertyContainsAny(ctx, containsAnyMatch[1], values);
+        }
+        // property.isEmpty()
+        const isEmptyMatch = trimmed.match(/^(\w+)\.isEmpty\(\)$/);
+        if (isEmptyMatch && isEmptyMatch[1]) {
+            return this.isEmpty(ctx, isEmptyMatch[1]);
+        }
+        // file.ctime/file.mtime comparisons with today()
+        const fileDateMatch = trimmed.match(/^file\.(ctime|mtime)\s*(>|<|>=|<=|==|!=)\s*today\(\)\s*-\s*["'](\d+)d["']$/);
+        if (fileDateMatch && fileDateMatch[1] && fileDateMatch[2] && fileDateMatch[3]) {
+            const field = fileDateMatch[1];
+            const op = fileDateMatch[2];
+            const days = parseInt(fileDateMatch[3], 10);
+            const compareDate = this.daysAgo(days);
+            const fileDate = ctx[field];
+            return this.compareDates(fileDate, op, compareDate);
+        }
+        // frontmatter date property comparisons with today()
+        const datePropMatch = trimmed.match(/^(\w+)\s*(>|<|>=|<=|==|!=)\s*today\(\)\s*-\s*["'](\d+)d["']$/);
+        if (datePropMatch && datePropMatch[1] && datePropMatch[2] && datePropMatch[3]) {
+            const prop = datePropMatch[1];
+            const op = datePropMatch[2];
+            const days = parseInt(datePropMatch[3], 10);
+            const compareDate = this.daysAgo(days);
+            const propValue = ctx.frontmatter[prop];
+            if (!propValue)
+                return false;
+            const propDate = new Date(propValue);
+            if (isNaN(propDate.getTime()))
+                return false;
+            return this.compareDates(propDate, op, compareDate);
+        }
+        // property == "value" or property == value
+        const eqMatch = trimmed.match(/^(\w+(?:\.\w+)?)\s*==\s*["']?(.+?)["']?$/);
+        if (eqMatch && eqMatch[1] && eqMatch[2]) {
+            return this.propertyEquals(ctx, eqMatch[1], eqMatch[2]);
+        }
+        // property != "value" or property != value
+        const neqMatch = trimmed.match(/^(\w+(?:\.\w+)?)\s*!=\s*["']?(.+?)["']?$/);
+        if (neqMatch && neqMatch[1] && neqMatch[2]) {
+            return !this.propertyEquals(ctx, neqMatch[1], neqMatch[2]);
+        }
+        // Unsupported expression - warn and return true (graceful degradation)
+        this.warnings.push(`Unsupported filter: ${trimmed}`);
+        return true;
+    }
+    hasTag(ctx, tag) {
+        const normalizedTag = tag.startsWith('#') ? tag.slice(1) : tag;
+        return ctx.tags.some(t => {
+            if (typeof t !== 'string')
+                return false;
+            return t === normalizedTag || t === `#${normalizedTag}`;
+        });
+    }
+    tagsContains(ctx, substring) {
+        const normalized = substring.startsWith('#') ? substring.slice(1) : substring;
+        return ctx.tags.some(t => {
+            if (typeof t !== 'string')
+                return false;
+            const tagNorm = t.startsWith('#') ? t.slice(1) : t;
+            return tagNorm.includes(normalized);
+        });
+    }
+    propertyContains(ctx, prop, substring) {
+        const val = this.getPropertyValue(ctx, prop);
+        if (typeof val === 'string') {
+            return val.includes(substring);
+        }
+        if (Array.isArray(val)) {
+            return val.some(v => typeof v === 'string' && v.includes(substring));
+        }
+        return false;
+    }
+    propertyContainsAny(ctx, prop, values) {
+        const val = this.getPropertyValue(ctx, prop);
+        if (typeof val === 'string') {
+            return values.some(v => val.includes(v));
+        }
+        if (Array.isArray(val)) {
+            return val.some(item => typeof item === 'string' && values.some(v => item.includes(v)));
+        }
+        return false;
+    }
+    isEmpty(ctx, prop) {
+        const val = this.getPropertyValue(ctx, prop);
+        if (val === undefined || val === null)
+            return true;
+        if (typeof val === 'string')
+            return val.trim() === '';
+        if (Array.isArray(val))
+            return val.length === 0;
+        return false;
+    }
+    propertyEquals(ctx, prop, value) {
+        const val = this.getPropertyValue(ctx, prop);
+        if (val === undefined || val === null)
+            return false;
+        if (typeof val === 'string') {
+            return val === value;
+        }
+        if (typeof val === 'number') {
+            return val === Number(value);
+        }
+        if (typeof val === 'boolean') {
+            return val === (value === 'true');
+        }
+        if (Array.isArray(val)) {
+            return val.includes(value);
+        }
+        return String(val) === value;
+    }
+    getPropertyValue(ctx, prop) {
+        if (prop.startsWith('file.')) {
+            const field = prop.slice(5);
+            switch (field) {
+                case 'name': return ctx.fileName;
+                case 'path': return ctx.filePath;
+                case 'ctime': return ctx.ctime;
+                case 'mtime': return ctx.mtime;
+                case 'tags': return ctx.tags;
+            }
+        }
+        return ctx.frontmatter[prop];
+    }
+    daysAgo(days) {
+        const date = new Date();
+        date.setDate(date.getDate() - days);
+        date.setHours(0, 0, 0, 0);
+        return date;
+    }
+    compareDates(date, op, compareDate) {
+        const t1 = date.getTime();
+        const t2 = compareDate.getTime();
+        switch (op) {
+            case '>': return t1 > t2;
+            case '<': return t1 < t2;
+            case '>=': return t1 >= t2;
+            case '<=': return t1 <= t2;
+            case '==': return t1 === t2;
+            case '!=': return t1 !== t2;
+            default: return false;
+        }
+    }
+    parseStringArgs(argsStr) {
+        const results = [];
+        const regex = /["']([^"']+)["']/g;
+        let match;
+        while ((match = regex.exec(argsStr)) !== null) {
+            if (match[1]) {
+                results.push(match[1]);
+            }
+        }
+        return results;
+    }
+}

--- a/dist/src/pathfilter.js
+++ b/dist/src/pathfilter.js
@@ -14,6 +14,7 @@ export class PathFilter {
             '.md',
             '.markdown',
             '.txt',
+            '.base',
             ...config?.allowedExtensions || []
         ];
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.0",
-        "gray-matter": "^4.0.3"
+        "gray-matter": "^4.0.3",
+        "yaml": "^2.8.2"
       },
       "bin": {
         "mcp-obsidian": "dist/server.js"
@@ -2712,6 +2713,22 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zod": {
       "version": "4.1.13",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.20.0",
-    "gray-matter": "^4.0.3"
+    "gray-matter": "^4.0.3",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@types/node": "^24.10.1",

--- a/server.ts
+++ b/server.ts
@@ -10,6 +10,7 @@ import { FileSystemService } from "./src/filesystem.js";
 import { FrontmatterHandler } from "./src/frontmatter.js";
 import { PathFilter } from "./src/pathfilter.js";
 import { SearchService } from "./src/search.js";
+import { BasesService } from "./src/bases.js";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
@@ -59,11 +60,11 @@ if (!vaultPath) {
   process.exit(1);
 }
 
-// Initialize services
 const pathFilter = new PathFilter();
 const frontmatterHandler = new FrontmatterHandler();
 const fileSystem = new FileSystemService(vaultPath, pathFilter, frontmatterHandler);
 const searchService = new SearchService(vaultPath, pathFilter);
+const basesService = new BasesService(vaultPath, pathFilter, frontmatterHandler);
 
 const server = new Server({
   name: "mcp-obsidian",
@@ -366,6 +367,38 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ["path", "operation"]
         }
+      },
+      {
+        name: "read_base",
+        description: "Execute an Obsidian Base's filters and return matching notes. Bases are dynamic queries over vault notes. Can query the entire base or a specific named view.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            path: {
+              type: "string",
+              description: "Path to the .base file relative to vault root"
+            },
+            view: {
+              type: "string",
+              description: "Specific view name to query (applies view filters, sort, limit). Omit to use only global base filters."
+            },
+            limit: {
+              type: "number",
+              description: "Override result limit (default: view's limit or 50, max: 100)"
+            },
+            includeFrontmatter: {
+              type: "boolean",
+              description: "Include frontmatter in results (default: false)",
+              default: false
+            },
+            prettyPrint: {
+              type: "boolean",
+              description: "Format JSON response with indentation (default: false)",
+              default: false
+            }
+          },
+          required: ["path"]
+        }
       }
     ]
   };
@@ -600,6 +633,24 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             }
           ],
           isError: !result.success
+        };
+      }
+
+      case "read_base": {
+        const result = await basesService.queryBase({
+          path: trimmedArgs.path,
+          view: trimmedArgs.view,
+          limit: trimmedArgs.limit,
+          includeFrontmatter: trimmedArgs.includeFrontmatter
+        });
+        const indent = trimmedArgs.prettyPrint ? 2 : undefined;
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(result, null, indent)
+            }
+          ]
         };
       }
 

--- a/src/bases.test.ts
+++ b/src/bases.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { FilterParser } from './filter-parser.js';
+import type { NoteContext, FilterGroup } from './types.js';
+
+describe('FilterParser', () => {
+  let parser: FilterParser;
+  let baseContext: NoteContext;
+
+  beforeEach(() => {
+    parser = new FilterParser();
+    baseContext = {
+      filePath: 'Notes/test-note.md',
+      fileName: 'test-note.md',
+      frontmatter: {
+        tags: ['llms', 'ai/prompts'],
+        type: 'Book',
+        status: 'active',
+        author: 'John Doe',
+        date: '2025-01-01',
+        source: 'https://github.com/example/repo'
+      },
+      content: 'Some content with #inline-tag and #another/nested',
+      ctime: new Date('2025-01-01'),
+      mtime: new Date('2025-01-05'),
+      tags: ['llms', 'ai/prompts', 'inline-tag', 'another/nested']
+    };
+  });
+
+  describe('file.hasTag', () => {
+    it('matches exact tag', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['file.hasTag("llms")'] },
+        baseContext
+      );
+      expect(result.matches).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it('matches tag with hash prefix in expression', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['file.hasTag("#llms")'] },
+        baseContext
+      );
+      expect(result.matches).toBe(true);
+    });
+
+    it('returns false for missing tag', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['file.hasTag("nonexistent")'] },
+        baseContext
+      );
+      expect(result.matches).toBe(false);
+    });
+  });
+
+  describe('tags.contains', () => {
+    it('matches substring in tag', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['tags.contains("ai/prompts")'] },
+        baseContext
+      );
+      expect(result.matches).toBe(true);
+    });
+
+    it('matches partial tag path', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['tags.contains("ai/")'] },
+        baseContext
+      );
+      expect(result.matches).toBe(true);
+    });
+
+    it('matches inline tags', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['tags.contains("inline-tag")'] },
+        baseContext
+      );
+      expect(result.matches).toBe(true);
+    });
+  });
+
+  describe('file.path.startsWith', () => {
+    it('matches path prefix', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['file.path.startsWith("Notes/")'] },
+        baseContext
+      );
+      expect(result.matches).toBe(true);
+    });
+
+    it('returns false for non-matching prefix', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['file.path.startsWith("Other/")'] },
+        baseContext
+      );
+      expect(result.matches).toBe(false);
+    });
+  });
+
+  describe('property equality', () => {
+    it('matches string property', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['type == "Book"'] },
+        baseContext
+      );
+      expect(result.matches).toBe(true);
+    });
+
+    it('handles inequality', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['status != "archived"'] },
+        baseContext
+      );
+      expect(result.matches).toBe(true);
+    });
+
+    it('returns false for non-matching value', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['type == "Movie"'] },
+        baseContext
+      );
+      expect(result.matches).toBe(false);
+    });
+  });
+
+  describe('property.contains', () => {
+    it('matches string property containing substring', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['source.contains("github")'] },
+        baseContext
+      );
+      expect(result.matches).toBe(true);
+    });
+
+    it('returns false for non-matching substring', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['source.contains("gitlab")'] },
+        baseContext
+      );
+      expect(result.matches).toBe(false);
+    });
+  });
+
+  describe('property.containsAny', () => {
+    it('matches any of multiple substrings', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['source.containsAny("gitlab", "github")'] },
+        baseContext
+      );
+      expect(result.matches).toBe(true);
+    });
+
+    it('returns false when none match', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['source.containsAny("gitlab", "bitbucket")'] },
+        baseContext
+      );
+      expect(result.matches).toBe(false);
+    });
+  });
+
+  describe('property.isEmpty', () => {
+    it('returns true for undefined property', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['updated.isEmpty()'] },
+        baseContext
+      );
+      expect(result.matches).toBe(true);
+    });
+
+    it('returns false for existing property', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['type.isEmpty()'] },
+        baseContext
+      );
+      expect(result.matches).toBe(false);
+    });
+  });
+
+  describe('date comparisons', () => {
+    it('handles file.ctime comparison with today()', () => {
+      const recentContext = {
+        ...baseContext,
+        ctime: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000)
+      };
+      const result = parser.evaluateFilterGroup(
+        { and: ['file.ctime > today() - "7d"'] },
+        recentContext
+      );
+      expect(result.matches).toBe(true);
+    });
+
+    it('handles file.mtime comparison', () => {
+      const recentContext = {
+        ...baseContext,
+        mtime: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000)
+      };
+      const result = parser.evaluateFilterGroup(
+        { and: ['file.mtime > today() - "7d"'] },
+        recentContext
+      );
+      expect(result.matches).toBe(true);
+    });
+
+    it('handles frontmatter date property comparison', () => {
+      const recentContext = {
+        ...baseContext,
+        frontmatter: {
+          ...baseContext.frontmatter,
+          date: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString()
+        }
+      };
+      const result = parser.evaluateFilterGroup(
+        { and: ['date > today() - "7d"'] },
+        recentContext
+      );
+      expect(result.matches).toBe(true);
+    });
+  });
+
+  describe('logical operators', () => {
+    it('handles AND with all matching', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['type == "Book"', 'file.hasTag("llms")'] },
+        baseContext
+      );
+      expect(result.matches).toBe(true);
+    });
+
+    it('handles AND with one not matching', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['type == "Book"', 'type == "Movie"'] },
+        baseContext
+      );
+      expect(result.matches).toBe(false);
+    });
+
+    it('handles OR with one matching', () => {
+      const result = parser.evaluateFilterGroup(
+        { or: ['type == "Book"', 'type == "Movie"'] },
+        baseContext
+      );
+      expect(result.matches).toBe(true);
+    });
+
+    it('handles OR with none matching', () => {
+      const result = parser.evaluateFilterGroup(
+        { or: ['type == "Movie"', 'type == "Show"'] },
+        baseContext
+      );
+      expect(result.matches).toBe(false);
+    });
+
+    it('handles nested groups', () => {
+      const group: FilterGroup = {
+        and: [
+          'type == "Book"',
+          { or: ['status == "active"', 'status == "pending"'] }
+        ]
+      };
+      const result = parser.evaluateFilterGroup(group, baseContext);
+      expect(result.matches).toBe(true);
+    });
+  });
+
+  describe('unsupported expressions', () => {
+    it('returns warning and matches for unsupported syntax', () => {
+      const result = parser.evaluateFilterGroup(
+        { and: ['author.contains(link("Dylan Shade", "dpshade"))'] },
+        baseContext
+      );
+      expect(result.matches).toBe(true);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain('Unsupported filter');
+    });
+  });
+
+  describe('empty/undefined filters', () => {
+    it('returns true for undefined filter group', () => {
+      const result = parser.evaluateFilterGroup(undefined, baseContext);
+      expect(result.matches).toBe(true);
+    });
+
+    it('returns true for empty filter group', () => {
+      const result = parser.evaluateFilterGroup({}, baseContext);
+      expect(result.matches).toBe(true);
+    });
+  });
+});

--- a/src/bases.ts
+++ b/src/bases.ts
@@ -1,0 +1,274 @@
+import { join, resolve, relative } from 'path';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { parse as parseYaml } from 'yaml';
+import type { PathFilter } from './pathfilter.js';
+import type { FrontmatterHandler } from './frontmatter.js';
+import type { 
+  BaseFile, 
+  BaseView, 
+  BaseQueryParams, 
+  BaseQueryResult, 
+  BaseNoteResult,
+  NoteContext,
+  FilterGroup,
+  SortSpec
+} from './types.js';
+import { FilterParser } from './filter-parser.js';
+
+export class BasesService {
+  private filterParser: FilterParser;
+
+  constructor(
+    private vaultPath: string,
+    private pathFilter: PathFilter,
+    private frontmatterHandler: FrontmatterHandler
+  ) {
+    this.vaultPath = resolve(vaultPath);
+    this.filterParser = new FilterParser();
+  }
+
+  async readBase(basePath: string): Promise<BaseFile> {
+    const fullPath = this.resolvePath(basePath);
+    
+    if (!basePath.endsWith('.base')) {
+      throw new Error(`Not a base file: ${basePath}`);
+    }
+
+    const content = await readFile(fullPath, 'utf-8');
+    const parsed = parseYaml(content) as BaseFile;
+    
+    return parsed || { views: [] };
+  }
+
+  async queryBase(params: BaseQueryParams): Promise<BaseQueryResult> {
+    const { path: basePath, view: viewName, limit, includeFrontmatter } = params;
+    
+    const base = await this.readBase(basePath);
+    const availableViews = base.views?.map(v => v.name) || [];
+    const allWarnings: string[] = [];
+
+    let targetView: BaseView | undefined;
+    if (viewName) {
+      targetView = base.views?.find(v => v.name === viewName);
+      if (!targetView) {
+        throw new Error(
+          `View "${viewName}" not found. Available views: ${availableViews.join(', ') || 'none'}`
+        );
+      }
+    }
+
+    const allNotes = await this.getAllNoteContexts();
+    
+    let matchingNotes = allNotes.filter(note => {
+      const result = this.filterParser.evaluateFilterGroup(base.filters, note);
+      allWarnings.push(...result.warnings);
+      return result.matches;
+    });
+
+    let filtersApplied = this.countFilters(base.filters);
+
+    if (targetView?.filters) {
+      matchingNotes = matchingNotes.filter(note => {
+        const result = this.filterParser.evaluateFilterGroup(targetView!.filters, note);
+        allWarnings.push(...result.warnings);
+        return result.matches;
+      });
+      filtersApplied += this.countFilters(targetView.filters);
+    }
+
+    if (targetView?.sort) {
+      matchingNotes = this.sortNotes(matchingNotes, targetView.sort);
+    }
+
+    const effectiveLimit = Math.min(limit ?? targetView?.limit ?? 50, 100);
+    matchingNotes = matchingNotes.slice(0, effectiveLimit);
+
+    const notes: BaseNoteResult[] = matchingNotes.map(note => {
+      const result: BaseNoteResult = {
+        p: note.filePath,
+        t: note.fileName.replace(/\.md$/, '')
+      };
+      if (includeFrontmatter) {
+        result.fm = note.frontmatter;
+      }
+      return result;
+    });
+
+    const uniqueWarnings = [...new Set(allWarnings)];
+
+    const result: BaseQueryResult = {
+      notes,
+      views: availableViews,
+      q: {
+        view: viewName || null,
+        limit: effectiveLimit,
+        filters: filtersApplied
+      }
+    };
+
+    if (uniqueWarnings.length > 0) {
+      result.w = uniqueWarnings;
+    }
+
+    return result;
+  }
+
+  private async getAllNoteContexts(): Promise<NoteContext[]> {
+    const markdownFiles = await this.findMarkdownFiles(this.vaultPath);
+    const contexts: NoteContext[] = [];
+
+    for (const fullPath of markdownFiles) {
+      const relativePath = fullPath.substring(this.vaultPath.length + 1).replace(/\\/g, '/');
+      
+      if (!this.pathFilter.isAllowed(relativePath)) continue;
+      if (relativePath.endsWith('.base')) continue;
+
+      try {
+        const content = await readFile(fullPath, 'utf-8');
+        const stats = await stat(fullPath);
+        const parsed = this.frontmatterHandler.parse(content);
+        
+        const tags = this.extractTags(parsed.frontmatter, parsed.content);
+        const fileName = relativePath.split('/').pop() || relativePath;
+
+        contexts.push({
+          filePath: relativePath,
+          fileName,
+          frontmatter: parsed.frontmatter,
+          content: parsed.content,
+          ctime: stats.birthtime,
+          mtime: stats.mtime,
+          tags
+        });
+      } catch {
+        continue;
+      }
+    }
+
+    return contexts;
+  }
+
+  private extractTags(frontmatter: Record<string, any>, content: string): string[] {
+    const tags: string[] = [];
+
+    if (frontmatter.tags) {
+      if (Array.isArray(frontmatter.tags)) {
+        for (const t of frontmatter.tags) {
+          if (typeof t === 'string') {
+            tags.push(t);
+          }
+        }
+      } else if (typeof frontmatter.tags === 'string') {
+        tags.push(frontmatter.tags);
+      }
+    }
+
+    const inlineMatches = content.match(/#[a-zA-Z0-9_\-/]+/g) || [];
+    const inlineTags = inlineMatches.map(tag => tag.slice(1));
+    tags.push(...inlineTags);
+
+    return [...new Set(tags)];
+  }
+
+  private sortNotes(notes: NoteContext[], sorts: SortSpec[]): NoteContext[] {
+    return [...notes].sort((a, b) => {
+      for (const sort of sorts) {
+        const aVal = this.getSortValue(a, sort.property);
+        const bVal = this.getSortValue(b, sort.property);
+        
+        const cmp = this.compareValues(aVal, bVal);
+        if (cmp !== 0) {
+          return sort.direction === 'DESC' ? -cmp : cmp;
+        }
+      }
+      return 0;
+    });
+  }
+
+  private getSortValue(note: NoteContext, prop: string): any {
+    if (prop.startsWith('file.')) {
+      const field = prop.slice(5);
+      switch (field) {
+        case 'name': return note.fileName;
+        case 'path': return note.filePath;
+        case 'ctime': return note.ctime;
+        case 'mtime': return note.mtime;
+      }
+    }
+    if (prop.startsWith('property.')) {
+      return note.frontmatter[prop.slice(9)];
+    }
+    return note.frontmatter[prop];
+  }
+
+  private compareValues(a: any, b: any): number {
+    if (a === undefined && b === undefined) return 0;
+    if (a === undefined) return 1;
+    if (b === undefined) return -1;
+
+    if (a instanceof Date && b instanceof Date) {
+      return a.getTime() - b.getTime();
+    }
+
+    if (typeof a === 'number' && typeof b === 'number') {
+      return a - b;
+    }
+
+    return String(a).localeCompare(String(b));
+  }
+
+  private countFilters(group: FilterGroup | undefined): number {
+    if (!group) return 0;
+    
+    let count = 0;
+    const items = group.and || group.or || [];
+    for (const item of items) {
+      if (typeof item === 'string') {
+        count++;
+      } else {
+        count += this.countFilters(item);
+      }
+    }
+    return count;
+  }
+
+  private async findMarkdownFiles(dirPath: string): Promise<string[]> {
+    const files: string[] = [];
+
+    try {
+      const entries = await readdir(dirPath, { withFileTypes: true });
+
+      for (const entry of entries) {
+        const fullPath = join(dirPath, entry.name);
+
+        if (entry.isDirectory()) {
+          if (entry.name.startsWith('.') || entry.name === 'node_modules') {
+            continue;
+          }
+          const subFiles = await this.findMarkdownFiles(fullPath);
+          files.push(...subFiles);
+        } else if (entry.isFile() && entry.name.endsWith('.md')) {
+          files.push(fullPath);
+        }
+      }
+    } catch {
+    }
+
+    return files;
+  }
+
+  private resolvePath(relativePath: string): string {
+    const normalizedPath = relativePath.startsWith('/')
+      ? relativePath.slice(1)
+      : relativePath;
+
+    const fullPath = resolve(join(this.vaultPath, normalizedPath));
+
+    const relativeToVault = relative(this.vaultPath, fullPath);
+    if (relativeToVault.startsWith('..')) {
+      throw new Error(`Path traversal not allowed: ${relativePath}`);
+    }
+
+    return fullPath;
+  }
+}

--- a/src/filter-parser.ts
+++ b/src/filter-parser.ts
@@ -1,0 +1,242 @@
+import type { NoteContext, FilterGroup, FilterItem } from './types.js';
+
+export interface FilterEvalResult {
+  matches: boolean;
+  warnings: string[];
+}
+
+export class FilterParser {
+  private warnings: string[] = [];
+
+  evaluateFilterGroup(group: FilterGroup | undefined, ctx: NoteContext): FilterEvalResult {
+    this.warnings = [];
+    
+    if (!group) {
+      return { matches: true, warnings: [] };
+    }
+
+    const matches = this.evalGroup(group, ctx);
+    return { matches, warnings: this.warnings };
+  }
+
+  private evalGroup(group: FilterGroup, ctx: NoteContext): boolean {
+    if (group.and) {
+      return group.and.every(item => this.evalItem(item, ctx));
+    }
+    if (group.or) {
+      return group.or.some(item => this.evalItem(item, ctx));
+    }
+    return true;
+  }
+
+  private evalItem(item: FilterItem, ctx: NoteContext): boolean {
+    if (typeof item === 'string') {
+      return this.evalExpression(item, ctx);
+    }
+    return this.evalGroup(item, ctx);
+  }
+
+  private evalExpression(expr: string, ctx: NoteContext): boolean {
+    const trimmed = expr.trim();
+
+    // file.hasTag("x")
+    const hasTagMatch = trimmed.match(/^file\.hasTag\(["'](.+?)["']\)$/);
+    if (hasTagMatch && hasTagMatch[1]) {
+      return this.hasTag(ctx, hasTagMatch[1]);
+    }
+
+    // tags.contains("x") or file.tags.contains("x")
+    const tagsContainsMatch = trimmed.match(/^(?:file\.)?tags\.contains\(["'](.+?)["']\)$/);
+    if (tagsContainsMatch && tagsContainsMatch[1]) {
+      return this.tagsContains(ctx, tagsContainsMatch[1]);
+    }
+
+    // file.path.startsWith("x")
+    const pathStartsMatch = trimmed.match(/^file\.path\.startsWith\(["'](.+?)["']\)$/);
+    if (pathStartsMatch && pathStartsMatch[1]) {
+      return ctx.filePath.startsWith(pathStartsMatch[1]);
+    }
+
+    // property.startsWith("x")
+    const propStartsMatch = trimmed.match(/^(\w+)\.startsWith\(["'](.+?)["']\)$/);
+    if (propStartsMatch && propStartsMatch[1] && propStartsMatch[2] && propStartsMatch[1] !== 'file') {
+      const val = ctx.frontmatter[propStartsMatch[1]];
+      return typeof val === 'string' && val.startsWith(propStartsMatch[2]);
+    }
+
+    // property.contains("x")
+    const propContainsMatch = trimmed.match(/^(\w+)\.contains\(["'](.+?)["']\)$/);
+    if (propContainsMatch && propContainsMatch[1] && propContainsMatch[2]) {
+      return this.propertyContains(ctx, propContainsMatch[1], propContainsMatch[2]);
+    }
+
+    // property.containsAny("x", "y", ...)
+    const containsAnyMatch = trimmed.match(/^(\w+)\.containsAny\((.+)\)$/);
+    if (containsAnyMatch && containsAnyMatch[1] && containsAnyMatch[2]) {
+      const values = this.parseStringArgs(containsAnyMatch[2]);
+      return this.propertyContainsAny(ctx, containsAnyMatch[1], values);
+    }
+
+    // property.isEmpty()
+    const isEmptyMatch = trimmed.match(/^(\w+)\.isEmpty\(\)$/);
+    if (isEmptyMatch && isEmptyMatch[1]) {
+      return this.isEmpty(ctx, isEmptyMatch[1]);
+    }
+
+    // file.ctime/file.mtime comparisons with today()
+    const fileDateMatch = trimmed.match(/^file\.(ctime|mtime)\s*(>|<|>=|<=|==|!=)\s*today\(\)\s*-\s*["'](\d+)d["']$/);
+    if (fileDateMatch && fileDateMatch[1] && fileDateMatch[2] && fileDateMatch[3]) {
+      const field = fileDateMatch[1] as 'ctime' | 'mtime';
+      const op = fileDateMatch[2];
+      const days = parseInt(fileDateMatch[3], 10);
+      const compareDate = this.daysAgo(days);
+      const fileDate = ctx[field];
+      return this.compareDates(fileDate, op, compareDate);
+    }
+
+    // frontmatter date property comparisons with today()
+    const datePropMatch = trimmed.match(/^(\w+)\s*(>|<|>=|<=|==|!=)\s*today\(\)\s*-\s*["'](\d+)d["']$/);
+    if (datePropMatch && datePropMatch[1] && datePropMatch[2] && datePropMatch[3]) {
+      const prop = datePropMatch[1];
+      const op = datePropMatch[2];
+      const days = parseInt(datePropMatch[3], 10);
+      const compareDate = this.daysAgo(days);
+      const propValue = ctx.frontmatter[prop];
+      if (!propValue) return false;
+      const propDate = new Date(propValue);
+      if (isNaN(propDate.getTime())) return false;
+      return this.compareDates(propDate, op, compareDate);
+    }
+
+    // property == "value" or property == value
+    const eqMatch = trimmed.match(/^(\w+(?:\.\w+)?)\s*==\s*["']?(.+?)["']?$/);
+    if (eqMatch && eqMatch[1] && eqMatch[2]) {
+      return this.propertyEquals(ctx, eqMatch[1], eqMatch[2]);
+    }
+
+    // property != "value" or property != value
+    const neqMatch = trimmed.match(/^(\w+(?:\.\w+)?)\s*!=\s*["']?(.+?)["']?$/);
+    if (neqMatch && neqMatch[1] && neqMatch[2]) {
+      return !this.propertyEquals(ctx, neqMatch[1], neqMatch[2]);
+    }
+
+    // Unsupported expression - warn and return true (graceful degradation)
+    this.warnings.push(`Unsupported filter: ${trimmed}`);
+    return true;
+  }
+
+  private hasTag(ctx: NoteContext, tag: string): boolean {
+    const normalizedTag = tag.startsWith('#') ? tag.slice(1) : tag;
+    return ctx.tags.some(t => {
+      if (typeof t !== 'string') return false;
+      return t === normalizedTag || t === `#${normalizedTag}`;
+    });
+  }
+
+  private tagsContains(ctx: NoteContext, substring: string): boolean {
+    const normalized = substring.startsWith('#') ? substring.slice(1) : substring;
+    return ctx.tags.some(t => {
+      if (typeof t !== 'string') return false;
+      const tagNorm = t.startsWith('#') ? t.slice(1) : t;
+      return tagNorm.includes(normalized);
+    });
+  }
+
+  private propertyContains(ctx: NoteContext, prop: string, substring: string): boolean {
+    const val = this.getPropertyValue(ctx, prop);
+    if (typeof val === 'string') {
+      return val.includes(substring);
+    }
+    if (Array.isArray(val)) {
+      return val.some(v => typeof v === 'string' && v.includes(substring));
+    }
+    return false;
+  }
+
+  private propertyContainsAny(ctx: NoteContext, prop: string, values: string[]): boolean {
+    const val = this.getPropertyValue(ctx, prop);
+    if (typeof val === 'string') {
+      return values.some(v => val.includes(v));
+    }
+    if (Array.isArray(val)) {
+      return val.some(item => 
+        typeof item === 'string' && values.some(v => item.includes(v))
+      );
+    }
+    return false;
+  }
+
+  private isEmpty(ctx: NoteContext, prop: string): boolean {
+    const val = this.getPropertyValue(ctx, prop);
+    if (val === undefined || val === null) return true;
+    if (typeof val === 'string') return val.trim() === '';
+    if (Array.isArray(val)) return val.length === 0;
+    return false;
+  }
+
+  private propertyEquals(ctx: NoteContext, prop: string, value: string): boolean {
+    const val = this.getPropertyValue(ctx, prop);
+    if (val === undefined || val === null) return false;
+    
+    if (typeof val === 'string') {
+      return val === value;
+    }
+    if (typeof val === 'number') {
+      return val === Number(value);
+    }
+    if (typeof val === 'boolean') {
+      return val === (value === 'true');
+    }
+    if (Array.isArray(val)) {
+      return val.includes(value);
+    }
+    return String(val) === value;
+  }
+
+  private getPropertyValue(ctx: NoteContext, prop: string): unknown {
+    if (prop.startsWith('file.')) {
+      const field = prop.slice(5);
+      switch (field) {
+        case 'name': return ctx.fileName;
+        case 'path': return ctx.filePath;
+        case 'ctime': return ctx.ctime;
+        case 'mtime': return ctx.mtime;
+        case 'tags': return ctx.tags;
+      }
+    }
+    return ctx.frontmatter[prop];
+  }
+
+  private daysAgo(days: number): Date {
+    const date = new Date();
+    date.setDate(date.getDate() - days);
+    date.setHours(0, 0, 0, 0);
+    return date;
+  }
+
+  private compareDates(date: Date, op: string, compareDate: Date): boolean {
+    const t1 = date.getTime();
+    const t2 = compareDate.getTime();
+    switch (op) {
+      case '>': return t1 > t2;
+      case '<': return t1 < t2;
+      case '>=': return t1 >= t2;
+      case '<=': return t1 <= t2;
+      case '==': return t1 === t2;
+      case '!=': return t1 !== t2;
+      default: return false;
+    }
+  }
+
+  private parseStringArgs(argsStr: string): string[] {
+    const results: string[] = [];
+    const regex = /["']([^"']+)["']/g;
+    let match;
+    while ((match = regex.exec(argsStr)) !== null) {
+      if (match[1]) {
+        results.push(match[1]);
+      }
+    }
+    return results;
+  }
+}

--- a/src/pathfilter.ts
+++ b/src/pathfilter.ts
@@ -18,6 +18,7 @@ export class PathFilter {
       '.md',
       '.markdown',
       '.txt',
+      '.base',
       ...config?.allowedExtensions || []
     ];
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,3 +134,66 @@ export interface TagManagementResult {
   success: boolean;
   message?: string;
 }
+
+// Base types for Obsidian Bases support
+
+export interface BaseFile {
+  filters?: FilterGroup;
+  views?: BaseView[];
+}
+
+export interface FilterGroup {
+  and?: FilterItem[];
+  or?: FilterItem[];
+}
+
+export type FilterItem = string | FilterGroup;
+
+export interface BaseView {
+  type: 'table' | 'cards';
+  name: string;
+  filters?: FilterGroup;
+  limit?: number;
+  sort?: SortSpec[];
+  order?: string[];  // column order (ignored for query)
+}
+
+export interface SortSpec {
+  property: string;
+  direction: 'ASC' | 'DESC';
+}
+
+export interface BaseQueryParams {
+  path: string;
+  view?: string;
+  limit?: number;
+  includeFrontmatter?: boolean;
+}
+
+export interface BaseQueryResult {
+  notes: BaseNoteResult[];
+  views: string[];
+  q: {
+    view: string | null;
+    limit: number;
+    filters: number;  // count of filters applied
+  };
+  w?: string[];  // warnings
+}
+
+export interface BaseNoteResult {
+  p: string;   // path
+  t: string;   // title
+  fm?: Record<string, any>;  // frontmatter (optional)
+}
+
+// Context for filter evaluation
+export interface NoteContext {
+  filePath: string;
+  fileName: string;
+  frontmatter: Record<string, any>;
+  content: string;
+  ctime: Date;
+  mtime: Date;
+  tags: string[];  // extracted from frontmatter + inline
+}


### PR DESCRIPTION
## Summary

Add new MCP tool `read_base` to execute Obsidian Base filters and return matching notes. Bases are dynamic queries over vault notes using YAML filter definitions.

## Features

- Parse `.base` YAML files with filters and views
- Execute filter expressions against vault notes
- Support view-specific queries with sort and limit
- Graceful degradation for unsupported filter syntax (warns but continues)

## Supported Filter Expressions

| Expression | Example |
|------------|---------|
| `file.hasTag("x")` | `file.hasTag("llms")` |
| `tags.contains("x")` | `tags.contains("transcript/health")` |
| `file.path.startsWith("x")` | `file.path.startsWith("Bookmarks/repos")` |
| `property == "value"` | `type == "Book"` |
| `property != "value"` | `status != "archived"` |
| `property.isEmpty()` | `updated.isEmpty()` |
| `property.contains("x")` | `source.contains("github")` |
| `property.containsAny(...)` | `source.containsAny("github", "gitlab")` |
| `file.ctime > today() - "Nd"` | `file.ctime > today() - "7d"` |
| `file.mtime > today() - "Nd"` | `file.mtime > today() - "30d"` |

## Tool Usage

```json
{
  "name": "read_base",
  "arguments": {
    "path": "LLMs Base.base",
    "view": "Prompts",
    "limit": 10,
    "includeFrontmatter": false
  }
}
```

## Response Format

Token-optimized response with minified field names:

```json
{
  "notes": [
    {"p": "path/to/note.md", "t": "Note Title"}
  ],
  "views": ["Table", "Prompts"],
  "q": {"view": "Prompts", "limit": 10, "filters": 2},
  "w": ["Unsupported filter: author.contains(link(...))"]
}
```

## New Files

- `src/filter-parser.ts` - Expression evaluation engine
- `src/bases.ts` - BasesService class
- `src/bases.test.ts` - 28 unit tests

## Dependencies

- Added `yaml` package for parsing `.base` files

## Testing

- All 262 tests pass
- Tested against real vault with multiple `.base` files