### PR TITLE
fix: validate content/newString to prevent writing literal "undefined"

### DIFF
--- a/src/filesystem.test.ts
+++ b/src/filesystem.test.ts
@@ -234,6 +234,86 @@ test("patch note fails with empty newString", async () => {
   expect(result.message).toMatch(/empty|filled|required/i);
 });
 
+test("patch note fails with undefined newString", async () => {
+  const testPath = "test-note.md";
+  const content = "# Test Note\n\nSome content.";
+
+  await writeFile(join(testVaultPath, testPath), content);
+
+  const result = await fileSystem.patchNote({
+    path: testPath,
+    oldString: "content",
+    newString: undefined as any,
+    replaceAll: false
+  });
+
+  expect(result.success).toBe(false);
+  expect(result.message).toMatch(/empty|filled|required/i);
+
+  // Verify the note was NOT corrupted
+  const note = await fileSystem.readNote(testPath);
+  expect(note.content).not.toContain("undefined");
+  expect(note.content).toContain("Some content.");
+});
+
+test("patch note fails with null newString", async () => {
+  const testPath = "test-note.md";
+  const content = "# Test Note\n\nSome content.";
+
+  await writeFile(join(testVaultPath, testPath), content);
+
+  const result = await fileSystem.patchNote({
+    path: testPath,
+    oldString: "content",
+    newString: null as any,
+    replaceAll: false
+  });
+
+  expect(result.success).toBe(false);
+  expect(result.message).toMatch(/empty|filled|required/i);
+
+  // Verify the note was NOT corrupted
+  const note = await fileSystem.readNote(testPath);
+  expect(note.content).not.toContain("null");
+  expect(note.content).toContain("Some content.");
+});
+
+test("writeNote rejects undefined content", async () => {
+  const testPath = "test-note.md";
+
+  await expect(fileSystem.writeNote({
+    path: testPath,
+    content: undefined as any
+  })).rejects.toThrow(/Content is required/);
+});
+
+test("writeNote rejects null content", async () => {
+  const testPath = "test-note.md";
+
+  await expect(fileSystem.writeNote({
+    path: testPath,
+    content: null as any
+  })).rejects.toThrow(/Content is required/);
+});
+
+test("writeNote append with undefined content does not corrupt note", async () => {
+  const testPath = "test-note.md";
+  const content = "# Test Note\n\nOriginal content.";
+
+  await writeFile(join(testVaultPath, testPath), content);
+
+  await expect(fileSystem.writeNote({
+    path: testPath,
+    content: undefined as any,
+    mode: 'append'
+  })).rejects.toThrow(/Content is required/);
+
+  // Verify the note was NOT corrupted
+  const note = await fileSystem.readNote(testPath);
+  expect(note.content).not.toContain("undefined");
+  expect(note.content).toContain("Original content.");
+});
+
 test("patch note handles regex special characters literally", async () => {
   const testPath = "test-note.md";
   const content = "Price: $10.50 (special)";

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -85,6 +85,11 @@ export class FileSystemService {
       throw new Error(`Access denied: ${path}. This path is restricted (system files like .obsidian, .git, and dotfiles are not accessible).`);
     }
 
+    // Validate content is a defined string to prevent writing literal "undefined"
+    if (content === undefined || content === null) {
+      throw new Error(`Content is required for writing a note: ${path}. The content parameter must be a string.`);
+    }
+
     // Validate frontmatter if provided
     if (frontmatter) {
       const validation = this.frontmatterHandler.validate(frontmatter);
@@ -169,7 +174,7 @@ export class FileSystemService {
       };
     }
 
-    if (newString === '') {
+    if (!newString) {
       return {
         success: false,
         path,


### PR DESCRIPTION
`writeNote` and `patchNote` silently coerce `undefined`/`null` params to the string `"undefined"` via JS type coercion, corrupting notes.

This can happen when an MCP client omits a required parameter — the server doesn't validate before writing, so `String.prototype.replace()` and `writeFile()` happily convert `undefined` to `"undefined"`.

### Changes

- **`writeNote`**: throw if `content` is `undefined`/`null`
- **`patchNote`**: check `newString` for `undefined`/`null` (`=== ''` missed this)
- Tests covering all cases + verifying notes aren't corrupted