### PR TITLE
fix: correctly handle dotted directory paths in get_vault_stats

### DIFF
--- a/src/filesystem.test.ts
+++ b/src/filesystem.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, beforeEach, afterEach } from "vitest";
 import { FileSystemService } from "./filesystem.js";
+import { PathFilter } from "./pathfilter.js";
 import { writeFile, readFile, mkdir, mkdtemp, rm } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -1132,6 +1133,27 @@ test("get vault stats excludes filtered paths", async () => {
   expect(stats.totalFolders).toBe(0); // .obsidian and .git are filtered
   expect(stats.recentlyModified.map(f => f.path)).toContain("visible.md");
   expect(stats.recentlyModified.map(f => f.path)).not.toContain(".obsidian/config.json");
+});
+
+test("get vault stats excludes files matched by custom ** ignored patterns", async () => {
+  const customFilter = new PathFilter({
+    ignoredPatterns: ["ignored/**"]
+  });
+  const customFileSystem = new FileSystemService(testVaultPath, customFilter);
+
+  await mkdir(join(testVaultPath, "ignored"), { recursive: true });
+  await mkdir(join(testVaultPath, "ignored/nested"), { recursive: true });
+  await writeFile(join(testVaultPath, "ignored/something.md"), "# Disallowed 1");
+  await writeFile(join(testVaultPath, "ignored/nested/something.md"), "# Disallowed 2");
+  await writeFile(join(testVaultPath, "visible.md"), "# Visible");
+
+  const stats = await customFileSystem.getVaultStats(10);
+  const recentPaths = stats.recentlyModified.map(file => file.path);
+
+  expect(stats.totalNotes).toBe(1);
+  expect(recentPaths).toContain("visible.md");
+  expect(recentPaths).not.toContain("ignored/something.md");
+  expect(recentPaths).not.toContain("ignored/nested/something.md");
 });
 
 test("get vault stats includes notes inside directories that contain dots", async () => {

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -821,21 +821,19 @@ export class FileSystemService {
 
       for (const entry of entries) {
         const entryRelativePath = relativePath ? `${relativePath}/${entry.name}` : entry.name;
-
-        if (!this.pathFilter.isAllowed(entryRelativePath)) {
-          continue;
-        }
-
         const fullEntryPath = join(dirPath, entry.name);
 
         if (entry.isDirectory()) {
-          // Also check if directory contents would be filtered (e.g., .obsidian/**)
-          if (!this.pathFilter.isAllowed(`${entryRelativePath}/test.md`)) {
+          if (!this.pathFilter.isAllowedForListing(entryRelativePath)) {
             continue;
           }
           totalFolders++;
           await scanDirectory(fullEntryPath, entryRelativePath);
         } else if (entry.isFile()) {
+          if (!this.pathFilter.isAllowed(entryRelativePath)) {
+            continue;
+          }
+
           totalNotes++;
           const stats = await stat(fullEntryPath);
           totalSize += stats.size;


### PR DESCRIPTION
## Summary
This PR fixes path filtering in `get_vault_stats` by applying filters based on entry type:

- Directories are checked with `isAllowedForListing(...)`
- Files are checked with `isAllowed(...)`

Previously, directory entries could be filtered with file-extension logic too early, which caused valid dotted directory paths to be skipped in traversal.

## Problems
Before this fix, some directory names containing `.` were incorrectly treated as file-like paths and skipped during `get_vault_stats` traversal.

As a result:
- `notes` and `folders` were under-counted.
- `recent` could miss valid notes under dotted directories.
- Behavior was inconsistent: some dotted directory names were included, while others were skipped depending on how the segment after `.` was interpreted.

> Before (buggy result)
<img width="709" height="243" alt="스크린샷 2026-03-02 오후 12 57 26" src="https://github.com/user-attachments/assets/8a264046-f9ea-4fb3-b365-2d21e77b9170" />


> After (fixed result)
<img width="714" height="240" alt="image" src="https://github.com/user-attachments/assets/914da39b-2b53-43fa-97ca-5744519765e6" />

## Root cause
Directory entries were validated with `isAllowed(...)` before determining whether an entry was a directory or a file.
Because `isAllowed(...)` includes extension-style checks, certain dotted directory names were misclassified and filtered out prematurely.

## User-visible impact
- Notes under previously skipped dotted directories are now included in vault stats.
- The `recent` list from `get_vault_stats` now includes those notes correctly.
- Existing ignore behavior (including custom `**` patterns) remains intact.

## Changes
- Updated `getVaultStats` traversal logic to separate directory filtering from file filtering.
- Added regression tests for:
  - dotted directory paths in stats traversal
  - custom `**` ignored-pattern exclusion in stats output

## Validation
- `npm run build` ✅
- `npm test` ✅