### PR TITLE
feat: support .base and .canvas Obsidian file types

### DIFF
--- a/src/pathfilter.test.ts
+++ b/src/pathfilter.test.ts
@@ -207,6 +207,12 @@ describe("PathFilter", () => {
     });
   });
 
+  test("allows Obsidian first-party file types", () => {
+    const filter = new PathFilter();
+    expect(filter.isAllowed("_Bases/daily-notes.base")).toBe(true);
+    expect(filter.isAllowed("canvas/mindmap.canvas")).toBe(true);
+  });
+
   // ============================================================================
   // FILTER PATHS BATCH OPERATION
   // ============================================================================

--- a/src/pathfilter.ts
+++ b/src/pathfilter.ts
@@ -21,6 +21,8 @@ export class PathFilter {
       '.md',
       '.markdown',
       '.txt',
+      '.base',    // Obsidian Bases (YAML)
+      '.canvas',  // Obsidian Canvas (JSON)
       ...config?.allowedExtensions || []
     ];
   }


### PR DESCRIPTION
Closes #52

## What
Adds `.base` and `.canvas` to the `allowedExtensions` whitelist in `PathFilter`.

## Why
Unlike binary attachments (png/pdf), these are first-party Obsidian text formats:
- `.base` — Obsidian Bases (YAML), introduced in v1.8
- `.canvas` — Obsidian Canvas (JSON)

They live inside the vault, are human-readable, and are part of core vault workflows. Blocking them makes it impossible to create or edit them via MCP.

## Changes
- `src/pathfilter.ts` — 2 lines added to `allowedExtensions`
- `src/pathfilter.test.ts` — 1 test case added