### PR TITLE
Rebrand mcp-obsidian to mcpvault

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-MCP-Obsidian is a Model Context Protocol (MCP) server that provides a universal AI bridge for Obsidian vaults. It enables any MCP-compatible AI assistant (Claude, ChatGPT, Gemini, etc.) to safely read and write notes in Obsidian vaults while preserving YAML frontmatter and enforcing security boundaries.
+MCP-Vault is a Model Context Protocol (MCP) server that provides a universal AI bridge for Obsidian vaults. It enables any MCP-compatible AI assistant (Claude, ChatGPT, Gemini, etc.) to safely read and write notes in Obsidian vaults while preserving YAML frontmatter and enforcing security boundaries.
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Node.js compatibility**: Full Node.js runtime support (v18.0.0+)
-- **npm distribution**: Published as npm package `@mauricio.wolff/mcp-obsidian`
+- **npm distribution**: Published as npm package `mcpvault`
 - **TypeScript tooling**: Added tsx for development and tsc for building
 - **Vitest testing**: Replaced Bun test with Vitest test runner
 
@@ -182,7 +182,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Multi-platform support**: Claude Desktop, Claude Code, ChatGPT Desktop, IntelliJ IDEA support
 
 ### Changed
-- **Package scope**: Migrated to scoped npm package `@mauricio.wolff/mcp-obsidian`
+- **Package scope**: Migrated to scoped npm package `mcpvault`
 - **Documentation**: Made README AI-agnostic with comprehensive examples
 - **Version consistency**: Synchronized version across all files
 
@@ -198,7 +198,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Error handling**: Improved error messages and validation
 
 ### Changed
-- **Project name**: Renamed from mcp-fs-obsidian to mcp-obsidian
+- **Project name**: Renamed from mcp-fs-obsidian to mcpvault
 - **Bun optimization**: Pure Bun implementation with native APIs
 - **Documentation**: Significantly improved README with examples
 
@@ -233,7 +233,7 @@ If you were using the Bun version, update your configuration:
 ```json
 {
   "command": "bunx",
-  "args": ["mcp-obsidian", "/path/to/vault"]
+  "args": ["mcpvault", "/path/to/vault"]
 }
 ```
 
@@ -241,7 +241,7 @@ If you were using the Bun version, update your configuration:
 ```json
 {
   "command": "npx",
-  "args": ["@mauricio.wolff/mcp-obsidian@latest", "/path/to/vault"]
+  "args": ["mcpvault@latest", "/path/to/vault"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
   <img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/1e21d898-811b-42c2-a810-bf921dde0f58" />
 </div>
 
-# MCP-Obsidian
+# MCP-Vault
 
 A universal AI bridge for Obsidian vaults using the Model Context Protocol (MCP) standard. Connect any MCP-compatible AI assistant to your knowledge base - works with Claude, ChatGPT, and future AI tools. This server provides safe read/write access to your notes while preventing YAML frontmatter corruption.
 
 <div align="center">
   
-[https://mcp-obsidian.org](https://mcp-obsidian.org)
+[https://mcpvault.org](https://mcpvault.org)
 
 [Changelog](./CHANGELOG.md)
 
@@ -16,9 +16,9 @@ A universal AI bridge for Obsidian vaults using the Model Context Protocol (MCP)
 
 <div align="center">
 
-[![GitHub Stars](https://img.shields.io/github/stars/bitbonsai/mcp-obsidian?style=flat&logo=github&logoColor=white&color=9065ea&labelColor=262626)](https://github.com/bitbonsai/mcp-obsidian)
-[![npm version](https://img.shields.io/npm/v/@mauricio.wolff/mcp-obsidian?style=flat&logo=npm&logoColor=white&color=9065ea&labelColor=262626)](https://www.npmjs.com/package/@mauricio.wolff/mcp-obsidian)
-[![npm downloads](https://img.shields.io/npm/dt/@mauricio.wolff/mcp-obsidian?style=flat&logo=npm&logoColor=white&color=9065ea&labelColor=262626)](https://www.npmjs.com/package/@mauricio.wolff/mcp-obsidian)
+[![GitHub Stars](https://img.shields.io/github/stars/bitbonsai/mcpvault?style=flat&logo=github&logoColor=white&color=9065ea&labelColor=262626)](https://github.com/bitbonsai/mcpvault)
+[![npm version](https://img.shields.io/npm/v/mcpvault?style=flat&logo=npm&logoColor=white&color=9065ea&labelColor=262626)](https://www.npmjs.com/package/mcpvault)
+[![npm downloads](https://img.shields.io/npm/dt/mcpvault?style=flat&logo=npm&logoColor=white&color=9065ea&labelColor=262626)](https://www.npmjs.com/package/mcpvault)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/BitBonsai?style=flat&logo=github&logoColor=white&color=9065ea&labelColor=262626)](https://github.com/sponsors/bitbonsai)
 [![Ko-Fi](https://img.shields.io/badge/Ko--fi-Support%20Me-9065ea?style=flat&logo=ko-fi&logoColor=white&labelColor=262626)](https://ko-fi.com/bitbonsai)
 [![Liberapay](https://img.shields.io/badge/Liberapay-Weekly%20Support-9065ea?style=flat&logo=liberapay&logoColor=white&labelColor=262626)](https://liberapay.com/bitbonsai/)
@@ -45,7 +45,7 @@ https://github.com/user-attachments/assets/657ac4c6-1cd2-4cc3-829f-fd095a32f71c
    If using the published package:
 
    ```bash
-   npx @modelcontextprotocol/inspector npx @mauricio.wolff/mcp-obsidian@latest /path/to/your/vault
+   npx @modelcontextprotocol/inspector npx mcpvault@latest /path/to/your/vault
    ```
 
 3. **Configure your AI client:**
@@ -57,7 +57,7 @@ https://github.com/user-attachments/assets/657ac4c6-1cd2-4cc3-829f-fd095a32f71c
      "mcpServers": {
        "obsidian": {
          "command": "npx",
-         "args": ["@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]
+         "args": ["mcpvault@latest", "/path/to/your/vault"]
        }
      }
    }
@@ -70,7 +70,7 @@ https://github.com/user-attachments/assets/657ac4c6-1cd2-4cc3-829f-fd095a32f71c
      "mcpServers": {
        "obsidian": {
          "command": "npx",
-         "args": ["@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"],
+         "args": ["mcpvault@latest", "/path/to/your/vault"],
          "env": {}
        }
      }
@@ -86,7 +86,7 @@ https://github.com/user-attachments/assets/657ac4c6-1cd2-4cc3-829f-fd095a32f71c
          "type": "local",
          "command": [
            "npx",
-           "@mauricio.wolff/mcp-obsidian@latest",
+           "mcpvault@latest",
            "/path/to/your/vault/"
          ],
          "enabled": true
@@ -106,15 +106,15 @@ https://github.com/user-attachments/assets/657ac4c6-1cd2-4cc3-829f-fd095a32f71c
 
 **Success indicators:** Your AI should be able to list files and read notes from your vault.
 
-## Why MCP-Obsidian?
+## Why MCP-Vault?
 
 ### Universal AI Compatibility
 
-Built on the open Model Context Protocol standard, MCP-Obsidian is not locked to any single AI provider. As more AI assistants adopt MCP, your investment in this tool grows more valuable. Today it works with Claude and ChatGPT - tomorrow it will work with whatever AI tools emerge.
+Built on the open Model Context Protocol standard, MCP-Vault is not locked to any single AI provider. As more AI assistants adopt MCP, your investment in this tool grows more valuable. Today it works with Claude and ChatGPT - tomorrow it will work with whatever AI tools emerge.
 
 ### Future-Proof Your Knowledge Base
 
-Instead of waiting for each AI company to build Obsidian integrations, MCP-Obsidian provides a universal adapter that works with any MCP-compatible assistant. One tool, endless possibilities.
+Instead of waiting for each AI company to build Obsidian integrations, MCP-Vault provides a universal adapter that works with any MCP-compatible assistant. One tool, endless possibilities.
 
 ### Open Standard, No Lock-in
 
@@ -155,7 +155,7 @@ MCP is an open protocol. You're not tied to any specific vendor or platform. You
 No installation needed! Use `npx` to run directly:
 
 ```bash
-npx @mauricio.wolff/mcp-obsidian@latest /path/to/your/obsidian/vault
+npx mcpvault@latest /path/to/your/obsidian/vault
 ```
 
 If you omit the vault path, the server uses your current working directory as the vault root.
@@ -188,7 +188,7 @@ npx @modelcontextprotocol/inspector npm start /path/to/your/vault
 npm install -g @modelcontextprotocol/inspector
 
 # Test with any vault
-mcp-inspector npx @mauricio.wolff/mcp-obsidian@latest /path/to/your/vault
+mcp-inspector npx mcpvault@latest /path/to/your/vault
 ```
 
 ## Usage
@@ -198,9 +198,9 @@ mcp-inspector npx @mauricio.wolff/mcp-obsidian@latest /path/to/your/vault
 **End users:**
 
 ```bash
-npx @mauricio.wolff/mcp-obsidian@latest
-npx @mauricio.wolff/mcp-obsidian@latest /path/to/your/obsidian/vault
-npx @mauricio.wolff/mcp-obsidian@latest ./Vault
+npx mcpvault@latest
+npx mcpvault@latest /path/to/your/obsidian/vault
+npx mcpvault@latest ./Vault
 ```
 
 **Developers:**
@@ -225,7 +225,7 @@ Add to your Claude Desktop configuration file:
     "obsidian": {
       "command": "npx",
       "args": [
-        "@mauricio.wolff/mcp-obsidian@latest",
+        "mcpvault@latest",
         "/Users/yourname/Documents/MyVault"
       ]
     }
@@ -241,14 +241,14 @@ Add to your Claude Desktop configuration file:
     "obsidian-personal": {
       "command": "npx",
       "args": [
-        "@mauricio.wolff/mcp-obsidian@latest",
+        "mcpvault@latest",
         "/Users/yourname/Documents/PersonalVault"
       ]
     },
     "obsidian-work": {
       "command": "npx",
       "args": [
-        "@mauricio.wolff/mcp-obsidian@latest",
+        "mcpvault@latest",
         "/Users/yourname/Documents/WorkVault"
       ]
     }
@@ -288,7 +288,7 @@ Edit `~/.claude.json`:
   "mcpServers": {
     "obsidian": {
       "command": "npx",
-      "args": ["@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"],
+      "args": ["mcpvault@latest", "/path/to/your/vault"],
       "env": {}
     }
   }
@@ -305,7 +305,7 @@ Edit `.claude.json` in your project or add to the projects section:
       "mcpServers": {
         "obsidian": {
           "command": "npx",
-          "args": ["@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]
+          "args": ["mcpvault@latest", "/path/to/your/vault"]
         }
       }
     }
@@ -316,7 +316,7 @@ Edit `.claude.json` in your project or add to the projects section:
 **Using Claude Code CLI:**
 
 ```bash
-claude mcp add obsidian --scope user npx @mauricio.wolff/mcp-obsidian /path/to/your/vault
+claude mcp add obsidian --scope user npx mcpvault /path/to/your/vault
 ```
 
 #### Goose Desktop
@@ -324,7 +324,7 @@ claude mcp add obsidian --scope user npx @mauricio.wolff/mcp-obsidian /path/to/y
 On Goose Desktop settings, click **Add custom extension**, and on the command field add:
 
 ```bash
-npx @mauricio.wolff/mcp-obsidian@latest /path/to/your/vault
+npx mcpvault@latest /path/to/your/vault
 ```
 
 #### Other MCP-Compatible Clients (2025)
@@ -372,7 +372,7 @@ Most modern MCP clients use similar JSON configuration patterns. Refer to your s
 #### "command not found: npx"
 
 - **Solution:** Install Node.js runtime from [nodejs.org](https://nodejs.org)
-- **Alternative:** Use global install: `npm install -g @mauricio.wolff/mcp-obsidian`
+- **Alternative:** Use global install: `npm install -g mcpvault`
 
 #### "File not found" when paths look correct
 
@@ -407,12 +407,12 @@ Most modern MCP clients use similar JSON configuration patterns. Refer to your s
 Run with error logging:
 
 ```bash
-npx @mauricio.wolff/mcp-obsidian /path/to/vault 2>debug.log
+npx mcpvault /path/to/vault 2>debug.log
 ```
 
 ### Getting Help
 
-- [Open an issue](https://github.com/bitbonsai/mcp-obsidian/issues) on GitHub
+- [Open an issue](https://github.com/bitbonsai/mcpvault/issues) on GitHub
 - Include your OS, Node.js version, and error messages
 - Provide the vault directory structure (without sensitive content)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@
 
 Instead, report them via GitHub's private vulnerability reporting:
 
-1. Go to the [Security tab](https://github.com/bitbonsai/mcp-obsidian/security)
+1. Go to the [Security tab](https://github.com/bitbonsai/mcpvault/security)
 2. Click "Report a vulnerability"
 3. Provide a detailed description
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
-  "name": "@mauricio.wolff/mcp-obsidian",
+  "name": "mcpvault",
   "version": "0.8.2",
   "description": "Universal AI bridge for Obsidian vaults - connect any MCP-compatible assistant",
+  "homepage": "https://mcpvault.org",
   "author": "bitbonsai",
   "license": "MIT",
   "type": "module",
   "packageManager": "npm@10.9.0+sha512.65a9c38a8172948f617a53619762cd77e12b9950fe1f9239debcb8d62c652f2081824b986fee7c0af6c0a7df615becebe4bf56e17ec27214a87aa29d9e038b4b",
   "main": "dist/server.js",
   "bin": {
-    "mcp-obsidian": "dist/server.js"
+    "mcpvault": "dist/server.js"
   },
   "files": [
     "dist/**/*",
@@ -42,7 +43,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bitbonsai/mcp-obsidian.git"
+    "url": "git+https://github.com/bitbonsai/mcpvault.git"
   },
   "keywords": [
     "mcp",

--- a/server.ts
+++ b/server.ts
@@ -33,12 +33,12 @@ if (firstArg === "--version" || firstArg === "-v") {
 
 if (firstArg === "--help" || firstArg === "-h") {
   console.log(`
-@mauricio.wolff/mcp-obsidian v${VERSION}
+mcpvault v${VERSION}
 
 Universal AI bridge for Obsidian vaults - connect any MCP-compatible assistant
 
 Usage:
-  npx @mauricio.wolff/mcp-obsidian [vault-path]
+  npx mcpvault [vault-path]
 
 Arguments:
   [vault-path]    Optional path to your Obsidian vault directory
@@ -49,11 +49,11 @@ Options:
   --help, -h      Show this help message
 
 Examples:
-  npx @mauricio.wolff/mcp-obsidian
-  npx @mauricio.wolff/mcp-obsidian ~/Documents/MyVault
-  npx @mauricio.wolff/mcp-obsidian ./Vault
-  npx @mauricio.wolff/mcp-obsidian /path/to/obsidian/vault
-  npx @mauricio.wolff/mcp-obsidian "/path/with spaces/Obsidian Vault"
+  npx mcpvault
+  npx mcpvault ~/Documents/MyVault
+  npx mcpvault ./Vault
+  npx mcpvault /path/to/obsidian/vault
+  npx mcpvault "/path/with spaces/Obsidian Vault"
 `);
   process.exit(0);
 }
@@ -70,7 +70,7 @@ const fileSystem = new FileSystemService(vaultPath, pathFilter, frontmatterHandl
 const searchService = new SearchService(vaultPath, pathFilter);
 
 const server = new Server({
-  name: "mcp-obsidian",
+  name: "mcpvault",
   version: VERSION
 }, {
   capabilities: {

--- a/src/filesystem.test.ts
+++ b/src/filesystem.test.ts
@@ -9,7 +9,7 @@ let testVaultPath: string;
 let fileSystem: FileSystemService;
 
 beforeEach(async () => {
-  testVaultPath = await mkdtemp(join(tmpdir(), "mcp-obsidian-test-"));
+  testVaultPath = await mkdtemp(join(tmpdir(), "mcpvault-test-"));
   fileSystem = new FileSystemService(testVaultPath);
 });
 
@@ -786,7 +786,7 @@ test("read from non-existent vault throws error", async () => {
 });
 
 test("write to non-existent vault creates directories", async () => {
-  const tempVault = await mkdtemp(join(tmpdir(), "mcp-obsidian-new-vault-"));
+  const tempVault = await mkdtemp(join(tmpdir(), "mcpvault-new-vault-"));
   const newFs = new FileSystemService(tempVault);
 
   try {

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -14,7 +14,7 @@ let fileSystem: FileSystemService;
 let searchService: SearchService;
 
 beforeEach(async () => {
-  testVaultPath = await mkdtemp(join(tmpdir(), "mcp-obsidian-integration-"));
+  testVaultPath = await mkdtemp(join(tmpdir(), "mcpvault-integration-"));
 
   // Initialize services (same as server.ts)
   pathFilter = new PathFilter();

--- a/src/search.test.ts
+++ b/src/search.test.ts
@@ -9,7 +9,7 @@ let testVaultPath: string;
 let searchService: SearchService;
 
 beforeEach(async () => {
-  testVaultPath = await mkdtemp(join(tmpdir(), "mcp-obsidian-search-"));
+  testVaultPath = await mkdtemp(join(tmpdir(), "mcpvault-search-"));
   searchService = new SearchService(testVaultPath, new PathFilter());
 });
 

--- a/website/README.md
+++ b/website/README.md
@@ -1,15 +1,15 @@
-# MCP-Obsidian Website
+# MCP-Vault Website
 
-🌐 **Live Site**: [mcp-obsidian.org](https://mcp-obsidian.org)
+🌐 **Live Site**: [mcpvault.org](https://mcpvault.org)
 
-This is the official landing page and documentation website for [MCP-Obsidian](https://github.com/bitbonsai/mcp-obsidian) - a Model Context Protocol (MCP) server that enables AI assistants like Claude to interact securely and intelligently with Obsidian vaults.
+This is the official landing page and documentation website for [MCP-Vault](https://github.com/bitbonsai/mcpvault) - a Model Context Protocol (MCP) server that enables AI assistants like Claude to interact securely and intelligently with Obsidian vaults.
 
 ## 🎯 Project Objective
 
 This website serves to:
 
-- **Showcase MCP-Obsidian**: Demonstrate the capabilities and benefits of connecting AI assistants to Obsidian
-- **Provide Installation Guide**: Clear, step-by-step instructions for setting up MCP-Obsidian
+- **Showcase MCP-Vault**: Demonstrate the capabilities and benefits of connecting AI assistants to Obsidian
+- **Provide Installation Guide**: Clear, step-by-step instructions for setting up MCP-Vault
 - **Interactive Demo**: Live demonstrations of AI-powered note management
 - **Documentation Hub**: Comprehensive guides, examples, and best practices
 - **Community Resource**: Links to support, contributions, and discussions
@@ -19,7 +19,7 @@ This website serves to:
 - **Modern Design**: Beautiful, responsive interface built with Astro and Tailwind CSS
 - **Interactive Demo**: Live terminal simulation showing AI-Obsidian interactions
 - **Code Examples**: Syntax-highlighted configuration examples
-- **Feature Comparison**: Clear comparison tables showing MCP-Obsidian advantages
+- **Feature Comparison**: Clear comparison tables showing MCP-Vault advantages
 - **Dark/Light Theme**: Automatic theme switching with system preferences
 - **Performance Optimized**: Static site generation for fast loading
 
@@ -43,8 +43,8 @@ This website serves to:
 
 1. **Clone the repository**:
    ```bash
-   git clone https://github.com/bitbonsai/mcp-obsidian.org.git
-   cd mcp-obsidian.org
+   git clone https://github.com/bitbonsai/mcpvault.org.git
+   cd mcpvault.org
    ```
 
 2. **Install dependencies**:
@@ -155,21 +155,21 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🔗 Related Projects
 
-- **[MCP-Obsidian](https://github.com/bitbonsai/mcp-obsidian)**: The main MCP server implementation
+- **[MCP-Vault](https://github.com/bitbonsai/mcpvault)**: The main MCP server implementation
 - **[Model Context Protocol](https://modelcontextprotocol.io)**: Protocol specification and tools
 - **[Obsidian](https://obsidian.md/)**: The knowledge management app
 
 ## 💬 Support & Community
 
-- **Issues**: [GitHub Issues](https://github.com/bitbonsai/mcp-obsidian/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/bitbonsai/mcp-obsidian/discussions)
+- **Issues**: [GitHub Issues](https://github.com/bitbonsai/mcpvault/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/bitbonsai/mcpvault/discussions)
 - **Author**: [@bitbonsai](https://github.com/bitbonsai)
 
 ---
 
 <div align="center">
 
-**[Visit Live Site](https://mcp-obsidian.org)** • **[View Source](https://github.com/bitbonsai/mcp-obsidian)**
+**[Visit Live Site](https://mcpvault.org)** • **[View Source](https://github.com/bitbonsai/mcpvault)**
 
 Made with ❤️ for the Obsidian community
 

--- a/website/package.json
+++ b/website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mcp-obsidian-site",
+  "name": "mcpvault-site",
   "type": "module",
   "version": "0.0.1",
   "scripts": {

--- a/website/public/demo.md
+++ b/website/public/demo.md
@@ -1,4 +1,4 @@
-# MCP-Obsidian Interactive Demo
+# MCP-Vault Interactive Demo
 
 See how AI assistants intelligently interact with your Obsidian vault. These examples show real conversations and outcomes.
 

--- a/website/public/features.md
+++ b/website/public/features.md
@@ -1,4 +1,4 @@
-# MCP-Obsidian Features
+# MCP-Vault Features
 
 Designed for safety, performance, and developer experience. Every feature gives AI intelligent access without compromising your data.
 
@@ -36,7 +36,7 @@ Works with Claude Desktop, ChatGPT+ Desktop, OpenCode, Gemini CLI, OpenAI Codex,
 
 ## Comparison with Alternatives
 
-| Feature | MCP-Obsidian | Other MCP-Obsidian (Plugin-based) | Direct File Access |
+| Feature | MCP-Vault | Other MCP-Vault (Plugin-based) | Direct File Access |
 |---------|-------------|----------------------------------|-------------------|
 | Setup Complexity | Simple - just point to vault path | Complex - requires Obsidian plugin + API key | Variable |
 | Obsidian Running Required | No | Yes | No |
@@ -52,10 +52,10 @@ Works with Claude Desktop, ChatGPT+ Desktop, OpenCode, Gemini CLI, OpenAI Codex,
 ## FAQ
 
 ### Does my data leave my computer?
-Vault files stay local. MCP-Obsidian reads and writes files on your machine. Your AI provider only sees content your client sends.
+Vault files stay local. MCP-Vault reads and writes files on your machine. Your AI provider only sees content your client sends.
 
 ### Does Obsidian need to be running?
-No. MCP-Obsidian works via filesystem access, so Obsidian can be closed.
+No. MCP-Vault works via filesystem access, so Obsidian can be closed.
 
 ### Can I use multiple vaults?
 Yes. Configure multiple MCP server entries, one per vault path.

--- a/website/public/how-it-works.md
+++ b/website/public/how-it-works.md
@@ -1,6 +1,6 @@
-# How MCP-Obsidian Works
+# How MCP-Vault Works
 
-Practical prompts you can try with your AI assistant and MCP-Obsidian.
+Practical prompts you can try with your AI assistant and MCP-Vault.
 
 ## Search & Read Notes
 

--- a/website/public/index.md
+++ b/website/public/index.md
@@ -1,4 +1,4 @@
-# MCP-Obsidian - Universal AI Bridge for Obsidian Vaults
+# MCP-Vault - Universal AI Bridge for Obsidian Vaults
 
 **License:** MIT | **Free**
 
@@ -7,7 +7,7 @@
 This MCP server lets Claude, ChatGPT+, and other assistants access your vault. Locally, safe frontmatter, no cloud sync.
 
 - [Get Started](/install) - Install and configure in seconds
-- [View on GitHub](https://github.com/bitbonsai/mcp-obsidian)
+- [View on GitHub](https://github.com/bitbonsai/mcpvault)
 
 ## Announcement
 
@@ -15,13 +15,13 @@ This MCP server lets Claude, ChatGPT+, and other assistants access your vault. L
 
 ## Recent Updates
 
-- **v0.8.2 (March 2026):** Trailing-slash vault paths no longer truncate search results ([PR #48](https://github.com/bitbonsai/mcp-obsidian/pull/48)), `get_vault_stats` now handles dotted folder names correctly ([PR #42](https://github.com/bitbonsai/mcp-obsidian/pull/42)), note tools now support `.base` and `.canvas` ([PR #53](https://github.com/bitbonsai/mcp-obsidian/pull/53)), string frontmatter inputs are now handled safely ([PR #47](https://github.com/bitbonsai/mcp-obsidian/pull/47)), vault path is now optional in CLI mode (defaults to current working directory, [#50](https://github.com/bitbonsai/mcp-obsidian/issues/50)), and dependency refreshes for the MCP SDK and Node types are merged ([PR #43](https://github.com/bitbonsai/mcp-obsidian/pull/43), [PR #44](https://github.com/bitbonsai/mcp-obsidian/pull/44))
-- **v0.8.1:** Multi-word BM25 search relevance improvements ([PR #38](https://github.com/bitbonsai/mcp-obsidian/pull/38)), patch_note undefined/null validation hardening ([PR #37](https://github.com/bitbonsai/mcp-obsidian/pull/37)), new `move_file` tool for binary-safe file moves with explicit path confirmation, binary filenames now visible in directory listings ([#21](https://github.com/bitbonsai/mcp-obsidian/issues/21))
-- **v0.7.5:** Search now matches note filenames ([#30](https://github.com/bitbonsai/mcp-obsidian/issues/30)), hidden directories filtered from listings ([#33](https://github.com/bitbonsai/mcp-obsidian/issues/33)), OpenCode install docs ([#35](https://github.com/bitbonsai/mcp-obsidian/issues/35))
+- **v0.8.2 (March 2026):** Trailing-slash vault paths no longer truncate search results ([PR #48](https://github.com/bitbonsai/mcpvault/pull/48)), `get_vault_stats` now handles dotted folder names correctly ([PR #42](https://github.com/bitbonsai/mcpvault/pull/42)), note tools now support `.base` and `.canvas` ([PR #53](https://github.com/bitbonsai/mcpvault/pull/53)), string frontmatter inputs are now handled safely ([PR #47](https://github.com/bitbonsai/mcpvault/pull/47)), vault path is now optional in CLI mode (defaults to current working directory, [#50](https://github.com/bitbonsai/mcpvault/issues/50)), and dependency refreshes for the MCP SDK and Node types are merged ([PR #43](https://github.com/bitbonsai/mcpvault/pull/43), [PR #44](https://github.com/bitbonsai/mcpvault/pull/44))
+- **v0.8.1:** Multi-word BM25 search relevance improvements ([PR #38](https://github.com/bitbonsai/mcpvault/pull/38)), patch_note undefined/null validation hardening ([PR #37](https://github.com/bitbonsai/mcpvault/pull/37)), new `move_file` tool for binary-safe file moves with explicit path confirmation, binary filenames now visible in directory listings ([#21](https://github.com/bitbonsai/mcpvault/issues/21))
+- **v0.7.5:** Search now matches note filenames ([#30](https://github.com/bitbonsai/mcpvault/issues/30)), hidden directories filtered from listings ([#33](https://github.com/bitbonsai/mcpvault/issues/33)), OpenCode install docs ([#35](https://github.com/bitbonsai/mcpvault/issues/35))
 - **v0.7.4:** New get_vault_stats tool + improved error messages with remediation suggestions
-- **v0.7.3:** Bug fix for folder detection with dots in names + dependency updates ([PR #15](https://github.com/bitbonsai/mcp-obsidian/pull/15))
-- **v0.7.2:** Security hardening - TOCTOU fixes, regex injection prevention, comprehensive CI/CD ([PR #12](https://github.com/bitbonsai/mcp-obsidian/pull/12))
-- [See full changelog](https://github.com/bitbonsai/mcp-obsidian/blob/main/CHANGELOG.md)
+- **v0.7.3:** Bug fix for folder detection with dots in names + dependency updates ([PR #15](https://github.com/bitbonsai/mcpvault/pull/15))
+- **v0.7.2:** Security hardening - TOCTOU fixes, regex injection prevention, comprehensive CI/CD ([PR #12](https://github.com/bitbonsai/mcpvault/pull/12))
+- [See full changelog](https://github.com/bitbonsai/mcpvault/blob/main/CHANGELOG.md)
 
 ## Navigation
 
@@ -33,7 +33,7 @@ This MCP server lets Claude, ChatGPT+, and other assistants access your vault. L
 
 ## Links
 
-- Repository: https://github.com/bitbonsai/mcp-obsidian
-- npm: https://www.npmjs.com/package/@mauricio.wolff/mcp-obsidian
-- Changelog: https://github.com/bitbonsai/mcp-obsidian/blob/main/CHANGELOG.md
-- Website: https://mcp-obsidian.org
+- Repository: https://github.com/bitbonsai/mcpvault
+- npm: https://www.npmjs.com/package/mcpvault
+- Changelog: https://github.com/bitbonsai/mcpvault/blob/main/CHANGELOG.md
+- Website: https://mcpvault.org

--- a/website/public/install.md
+++ b/website/public/install.md
@@ -1,6 +1,6 @@
-# Install MCP-Obsidian
+# Install MCP-Vault
 
-Get MCP-Obsidian running in seconds with any MCP-compatible platform.
+Get MCP-Vault running in seconds with any MCP-compatible platform.
 
 ## Step 1: Configure Your AI Platform
 
@@ -13,7 +13,7 @@ Add to your MCP configuration file:
   "mcpServers": {
     "obsidian": {
       "command": "npx",
-      "args": ["@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]
+      "args": ["mcpvault@latest", "/path/to/your/vault"]
     }
   }
 }
@@ -22,7 +22,7 @@ Add to your MCP configuration file:
 ### Claude Code
 
 ```bash
-claude mcp add-json obsidian --scope user '{"type":"stdio","command":"npx","args":["@mauricio.wolff/mcp-obsidian@latest","/path/to/your/vault"]}'
+claude mcp add-json obsidian --scope user '{"type":"stdio","command":"npx","args":["mcpvault@latest","/path/to/your/vault"]}'
 ```
 
 **Configuration Scopes:**
@@ -38,7 +38,7 @@ claude mcp add-json obsidian --scope user '{"type":"stdio","command":"npx","args
 opencode mcp add
 ```
 
-Select **local**, then enter the command: `npx -y @mauricio.wolff/mcp-obsidian@latest /path/to/your/vault`
+Select **local**, then enter the command: `npx -y mcpvault@latest /path/to/your/vault`
 
 **Option 2: Config file**
 
@@ -50,7 +50,7 @@ Add to your `opencode.json` (project root) or `~/.config/opencode/opencode.json`
   "mcp": {
     "obsidian": {
       "type": "local",
-      "command": ["npx", "-y", "@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]
+      "command": ["npx", "-y", "mcpvault@latest", "/path/to/your/vault"]
     }
   }
 }
@@ -61,7 +61,7 @@ Add to your `opencode.json` (project root) or `~/.config/opencode/opencode.json`
 **Option 1: CLI**
 
 ```bash
-gemini mcp add obsidian -- npx @mauricio.wolff/mcp-obsidian@latest /path/to/your/vault
+gemini mcp add obsidian -- npx mcpvault@latest /path/to/your/vault
 ```
 
 **Option 2: Config file**
@@ -73,7 +73,7 @@ Add to `~/.gemini/settings.json`:
   "mcpServers": {
     "obsidian": {
       "command": "npx",
-      "args": ["@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]
+      "args": ["mcpvault@latest", "/path/to/your/vault"]
     }
   }
 }
@@ -84,19 +84,19 @@ Add to `~/.gemini/settings.json`:
 ```toml
 [mcp_servers.obsidian]
 command = "npx"
-args = ["-y", "@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]
+args = ["-y", "mcpvault@latest", "/path/to/your/vault"]
 ```
 
 ### Optional no-path mode (uses current directory)
 
-If your client launches MCP-Obsidian from inside your vault folder, you can omit the vault path.
+If your client launches MCP-Vault from inside your vault folder, you can omit the vault path.
 
 ```bash
-npx @mauricio.wolff/mcp-obsidian@latest
+npx mcpvault@latest
 ```
 
 ```json
-"args": ["@mauricio.wolff/mcp-obsidian@latest"]
+"args": ["mcpvault@latest"]
 ```
 
 Supported note file types: `.md`, `.markdown`, `.txt`, `.base`, `.canvas`.
@@ -136,7 +136,7 @@ No pre-installation needed! npx automatically downloads and runs the server.
 
 ```bash
 npm install -g @modelcontextprotocol/inspector
-mcp-inspector npx @mauricio.wolff/mcp-obsidian@latest /path/to/vault
+mcp-inspector npx mcpvault@latest /path/to/vault
 ```
 
 Opens interactive web interface at http://localhost:5173 for testing all MCP methods.
@@ -155,4 +155,4 @@ Works with all MCP-compatible platforms: Claude Desktop, ChatGPT+, Claude Code, 
 
 ## You're All Set!
 
-Restart your AI platform and you'll see MCP-Obsidian connected. Your AI assistant can now safely read, search, and manage your Obsidian vault.
+Restart your AI platform and you'll see MCP-Vault connected. Your AI assistant can now safely read, search, and manage your Obsidian vault.

--- a/website/public/llm.txt
+++ b/website/public/llm.txt
@@ -1,21 +1,21 @@
-# MCP-Obsidian
+# MCP-Vault
 
 > Universal AI Bridge for Obsidian Vaults
 
-MCP-Obsidian is an open-source Model Context Protocol (MCP) server that gives AI assistants safe, intelligent access to Obsidian vaults. Works with Claude, ChatGPT, OpenCode, Gemini CLI, and any MCP-compatible platform. No plugins required, no Obsidian running needed.
+MCP-Vault is an open-source Model Context Protocol (MCP) server that gives AI assistants safe, intelligent access to Obsidian vaults. Works with Claude, ChatGPT, OpenCode, Gemini CLI, and any MCP-compatible platform. No plugins required, no Obsidian running needed.
 
 ## Docs
 
-- [Home](https://mcp-obsidian.org/index.md): Project overview, version info, recent updates
-- [Install](https://mcp-obsidian.org/install.md): Configuration for Claude Desktop, ChatGPT+, Claude Code, OpenCode, Gemini CLI, OpenAI Codex, with config file paths per platform and optional CWD mode
-- [Features](https://mcp-obsidian.org/features.md): Core features (BM25-ranked full-text search, frontmatter safety, security, token optimization), comparison table, and FAQ
-- [Demo](https://mcp-obsidian.org/demo.md): Real request/response examples for patch_note, write_note, read_multiple_notes, update_frontmatter, search_notes
-- [How It Works](https://mcp-obsidian.org/how-it-works.md): End-to-end usage flows and full list of 14 MCP tools with descriptions
-- [Skill](https://mcp-obsidian.org/skill.md): Obsidian skill combining MCP, Obsidian CLI/app context, and Git CLI sync. Covers routing rules, preflight checks, targeted questions, and safe sync defaults.
+- [Home](https://mcpvault.org/index.md): Project overview, version info, recent updates
+- [Install](https://mcpvault.org/install.md): Configuration for Claude Desktop, ChatGPT+, Claude Code, OpenCode, Gemini CLI, OpenAI Codex, with config file paths per platform and optional CWD mode
+- [Features](https://mcpvault.org/features.md): Core features (BM25-ranked full-text search, frontmatter safety, security, token optimization), comparison table, and FAQ
+- [Demo](https://mcpvault.org/demo.md): Real request/response examples for patch_note, write_note, read_multiple_notes, update_frontmatter, search_notes
+- [How It Works](https://mcpvault.org/how-it-works.md): End-to-end usage flows and full list of 14 MCP tools with descriptions
+- [Skill](https://mcpvault.org/skill.md): Obsidian skill combining MCP, Obsidian CLI/app context, and Git CLI sync. Covers routing rules, preflight checks, targeted questions, and safe sync defaults.
 
 ## Optional
 
-- [GitHub README](https://github.com/bitbonsai/mcp-obsidian/blob/main/README.md): Full developer documentation
-- [Changelog](https://github.com/bitbonsai/mcp-obsidian/blob/main/CHANGELOG.md): Release-by-release changes and migration notes
-- [npm Package](https://www.npmjs.com/package/@mauricio.wolff/mcp-obsidian): Package info and install instructions
-- [CONTRIBUTING](https://github.com/bitbonsai/mcp-obsidian/blob/main/CONTRIBUTING.md): How to contribute
+- [GitHub README](https://github.com/bitbonsai/mcpvault/blob/main/README.md): Full developer documentation
+- [Changelog](https://github.com/bitbonsai/mcpvault/blob/main/CHANGELOG.md): Release-by-release changes and migration notes
+- [npm Package](https://www.npmjs.com/package/mcpvault): Package info and install instructions
+- [CONTRIBUTING](https://github.com/bitbonsai/mcpvault/blob/main/CONTRIBUTING.md): How to contribute

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -2,7 +2,7 @@ User-agent: *
 Allow: /
 
 # Sitemaps
-Sitemap: https://mcp-obsidian.org/sitemap.xml
+Sitemap: https://mcpvault.org/sitemap.xml
 
 # AI crawlers
 User-agent: GPTBot

--- a/website/public/skill.md
+++ b/website/public/skill.md
@@ -5,7 +5,7 @@ Combines MCP server safety with Obsidian CLI context. One skill that routes each
 ## Install
 
 ```
-npx skills add bitbonsai/mcp-obsidian
+npx skills add bitbonsai/mcpvault
 ```
 
 ### What can you do with it?

--- a/website/src/components/CodeExample.astro
+++ b/website/src/components/CodeExample.astro
@@ -11,7 +11,7 @@ import { FolderOpen, Settings, Target, Zap } from 'lucide-react';
         Configuration Examples
       </h2>
       <p class="text-xl text-muted-foreground max-w-3xl mx-auto">
-        From basic setup to advanced configurations, here's how to customize MCP-Obsidian for your workflow.
+        From basic setup to advanced configurations, here's how to customize MCP-Vault for your workflow.
       </p>
     </div>
 
@@ -82,7 +82,7 @@ import { FolderOpen, Settings, Target, Zap } from 'lucide-react';
   "mcpServers": &#123;
     "obsidian": &#123;
       "command": "npx",
-      "args": ["@mauricio.wolff/mcp-obsidian@latest", "/Users/you/Documents/MyVault"]
+      "args": ["mcpvault@latest", "/Users/you/Documents/MyVault"]
     &#125;
   &#125;
 &#125;</code></pre>
@@ -100,7 +100,7 @@ import { FolderOpen, Settings, Target, Zap } from 'lucide-react';
                 Advanced Settings
               </h3>
               <p class="text-muted-foreground mb-6">
-                Fine-tune MCP-Obsidian's behavior with custom settings, logging, and performance options.
+                Fine-tune MCP-Vault's behavior with custom settings, logging, and performance options.
               </p>
               <div class="space-y-4">
                 <div class="flex items-center gap-2 text-sm text-accent">
@@ -136,7 +136,7 @@ import { FolderOpen, Settings, Target, Zap } from 'lucide-react';
     "obsidian": &#123;
       "command": "npx",
       "args": [
-        "@mauricio.wolff/mcp-obsidian@latest",
+        "mcpvault@latest",
         "/Users/you/Documents/MyVault",
         "--log-level", "debug",
         "--max-search-results", "50",
@@ -199,16 +199,16 @@ import { FolderOpen, Settings, Target, Zap } from 'lucide-react';
   "mcpServers": &#123;
     "obsidian-work": &#123;
       "command": "npx",
-      "args": ["@mauricio.wolff/mcp-obsidian@latest", "/Users/you/Work/Notes"]
+      "args": ["mcpvault@latest", "/Users/you/Work/Notes"]
     &#125;,
     "obsidian-personal": &#123;
       "command": "npx",
-      "args": ["@mauricio.wolff/mcp-obsidian@latest", "/Users/you/Personal/Journal"]
+      "args": ["mcpvault@latest", "/Users/you/Personal/Journal"]
     &#125;,
     "obsidian-research": &#123;
       "command": "npx",
       "args": [
-        "@mauricio.wolff/mcp-obsidian@latest",
+        "mcpvault@latest",
         "/Users/you/Research/Papers",
         "--read-only", "true"
       ]
@@ -265,7 +265,7 @@ import { FolderOpen, Settings, Target, Zap } from 'lucide-react';
     "obsidian": &#123;
       "command": "npx",
       "args": [
-        "@mauricio.wolff/mcp-obsidian@latest",
+        "mcpvault@latest",
         "/Users/you/Documents/MyVault",
         "--include-patterns", "*.md,!private/**",
         "--exclude-tags", "personal,draft",

--- a/website/src/components/ComparisonTable.astro
+++ b/website/src/components/ComparisonTable.astro
@@ -77,10 +77,10 @@ const statusIconColors: Record<string, string> = {
     <!-- Section header -->
     <div class="text-center mb-16 fade-in-on-scroll">
       <h2 class="text-4xl sm:text-5xl font-bold gradient-text mb-6">
-        Why Choose MCP-Obsidian?
+        Why Choose MCP-Vault?
       </h2>
       <p class="text-xl text-muted-foreground max-w-3xl mx-auto">
-        See how MCP-Obsidian compares to plugin-based alternatives and direct file manipulation.
+        See how MCP-Vault compares to plugin-based alternatives and direct file manipulation.
         Purpose-built for Obsidian means better safety, performance, and intelligence.
       </p>
     </div>
@@ -94,11 +94,11 @@ const statusIconColors: Record<string, string> = {
             <div class="grid grid-cols-4 gap-4 p-6">
               <div class="font-semibold text-foreground">Feature</div>
               <div class="text-center">
-                <div class="font-semibold text-accent mb-1">MCP-Obsidian</div>
+                <div class="font-semibold text-accent mb-1">MCP-Vault</div>
                 <div class="text-xs text-muted-foreground">This package</div>
               </div>
               <div class="text-center">
-                <div class="font-semibold text-muted-foreground mb-1">Other MCP-Obsidian</div>
+                <div class="font-semibold text-muted-foreground mb-1">Other MCP-Vault</div>
                 <div class="text-xs text-muted-foreground">Plugin-based</div>
               </div>
               <div class="text-center">
@@ -120,7 +120,7 @@ const statusIconColors: Record<string, string> = {
                   {feature.name}
                 </div>
 
-                <!-- MCP-Obsidian (This package) -->
+                <!-- MCP-Vault (This package) -->
                 <div class="text-center">
                   <div class="flex flex-col items-center gap-1 mb-2">
                     {(() => {
@@ -136,7 +136,7 @@ const statusIconColors: Record<string, string> = {
                   </div>
                 </div>
 
-                <!-- Other MCP-Obsidian (Plugin-based) -->
+                <!-- Other MCP-Vault (Plugin-based) -->
                 <div class="text-center">
                   <div class="flex flex-col items-center gap-1 mb-2">
                     {(() => {
@@ -206,7 +206,7 @@ const statusIconColors: Record<string, string> = {
             Install Now
           </a>
           <a
-            href="https://github.com/bitbonsai/mcp-obsidian"
+            href="https://github.com/bitbonsai/mcpvault"
             target="_blank"
             rel="noopener noreferrer"
             class="inline-flex items-center gap-2 px-6 py-3 rounded-xl border border-border/50 hover:border-accent/50 text-foreground font-semibold transition-all duration-300 glass"

--- a/website/src/components/FAQ.astro
+++ b/website/src/components/FAQ.astro
@@ -2,11 +2,11 @@
 const faqItems = [
   {
     q: 'Does my data leave my computer?',
-    a: 'Vault files stay on your machine. MCP-Obsidian reads and writes local files directly. Your AI provider only sees content that your client sends to it.'
+    a: 'Vault files stay on your machine. MCP-Vault reads and writes local files directly. Your AI provider only sees content that your client sends to it.'
   },
   {
     q: 'Does Obsidian need to be running?',
-    a: 'No. MCP-Obsidian uses filesystem access, so it works even when Obsidian is closed.'
+    a: 'No. MCP-Vault uses filesystem access, so it works even when Obsidian is closed.'
   },
   {
     q: 'Can I use multiple vaults?',

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -26,7 +26,7 @@
               </defs>
             </svg>
           </div>
-          <span class="text-xl font-bold text-foreground">MCP-Obsidian</span>
+          <span class="text-xl font-bold text-foreground">MCP-Vault</span>
         </div>
         <p class="text-muted-foreground max-w-md mb-6">
           Give AI safe, intelligent access to your Obsidian vault.
@@ -34,7 +34,7 @@
         </p>
         <div class="flex items-center gap-4">
           <a
-            href="https://github.com/bitbonsai/mcp-obsidian"
+            href="https://github.com/bitbonsai/mcpvault"
             target="_blank"
             rel="noopener noreferrer"
             class="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
@@ -45,7 +45,7 @@
             <span class="text-sm">GitHub Repository</span>
           </a>
           <a
-            href="https://www.npmjs.com/package/@mauricio.wolff/mcp-obsidian"
+            href="https://www.npmjs.com/package/mcpvault"
             target="_blank"
             rel="noopener noreferrer"
             class="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
@@ -74,10 +74,10 @@
       <div>
         <h3 class="text-sm font-semibold text-foreground uppercase tracking-wider mb-4">Community</h3>
         <div class="space-y-2">
-          <a href="https://github.com/bitbonsai/mcp-obsidian/issues" target="_blank" rel="noopener noreferrer" class="block text-muted-foreground hover:text-foreground transition-colors text-sm">Issues & Support</a>
-          <a href="https://github.com/bitbonsai/mcp-obsidian/discussions" target="_blank" rel="noopener noreferrer" class="block text-muted-foreground hover:text-foreground transition-colors text-sm">Discussions</a>
-          <a href="https://github.com/bitbonsai/mcp-obsidian/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer" class="block text-muted-foreground hover:text-foreground transition-colors text-sm">Changelog</a>
-          <a href="https://github.com/bitbonsai/mcp-obsidian/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" class="block text-muted-foreground hover:text-foreground transition-colors text-sm">Contributing</a>
+          <a href="https://github.com/bitbonsai/mcpvault/issues" target="_blank" rel="noopener noreferrer" class="block text-muted-foreground hover:text-foreground transition-colors text-sm">Issues & Support</a>
+          <a href="https://github.com/bitbonsai/mcpvault/discussions" target="_blank" rel="noopener noreferrer" class="block text-muted-foreground hover:text-foreground transition-colors text-sm">Discussions</a>
+          <a href="https://github.com/bitbonsai/mcpvault/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer" class="block text-muted-foreground hover:text-foreground transition-colors text-sm">Changelog</a>
+          <a href="https://github.com/bitbonsai/mcpvault/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" class="block text-muted-foreground hover:text-foreground transition-colors text-sm">Contributing</a>
           <a href="https://github.com/bitbonsai" target="_blank" rel="noopener noreferrer" class="block text-muted-foreground hover:text-foreground transition-colors text-sm">bitbonsai</a>
         </div>
       </div>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -85,7 +85,7 @@ import pkg from '../../../package.json';
         Get Started
       </a>
       <a
-        href="https://github.com/bitbonsai/mcp-obsidian"
+        href="https://github.com/bitbonsai/mcpvault"
         target="_blank"
         rel="noopener noreferrer"
         class="inline-flex items-center gap-2 px-8 py-4 rounded-xl border border-border/50 hover:border-accent/50 text-foreground font-semibold text-lg transition-all duration-300 glass group"
@@ -119,7 +119,7 @@ import pkg from '../../../package.json';
             height="720"
             poster="/video-poster-small.webp"
           >
-            <source src="/mcp-obsidian-1-min.mp4" type="video/mp4" />
+            <source src="/mcpvault-1-min.mp4" type="video/mp4" />
             Your browser does not support the video tag.
           </video>
         </div>
@@ -130,14 +130,14 @@ import pkg from '../../../package.json';
         class="flex flex-wrap items-center justify-center gap-3 mt-8 mb-8 opacity-75 hover:opacity-100 transition-opacity duration-300"
       >
         <a
-          href="https://github.com/bitbonsai/mcp-obsidian"
+          href="https://github.com/bitbonsai/mcpvault"
           target="_blank"
           rel="noopener noreferrer"
           class="transform hover:scale-105 transition-all duration-200 rounded hover:shadow-lg hover:shadow-accent/25"
           data-astro-cid-bbe6dxrz=""
         >
           <img
-            src="https://img.shields.io/github/stars/bitbonsai/mcp-obsidian?style=flat&logo=github&logoColor=white&color=9065ea&labelColor=262626"
+            src="https://img.shields.io/github/stars/bitbonsai/mcpvault?style=flat&logo=github&logoColor=white&color=9065ea&labelColor=262626"
             alt="GitHub Stars"
             class="h-6 rounded"
             loading="lazy"
@@ -145,26 +145,26 @@ import pkg from '../../../package.json';
           />
         </a>
         <a
-          href="https://www.npmjs.com/package/@mauricio.wolff/mcp-obsidian"
+          href="https://www.npmjs.com/package/mcpvault"
           target="_blank"
           rel="noopener noreferrer"
           class="transform hover:scale-105 transition-all duration-200 rounded hover:shadow-lg hover:shadow-accent/25"
         >
           <img
-            src="https://img.shields.io/npm/v/@mauricio.wolff/mcp-obsidian?style=flat&logo=npm&logoColor=white&color=9065ea&labelColor=262626"
+            src="https://img.shields.io/npm/v/mcpvault?style=flat&logo=npm&logoColor=white&color=9065ea&labelColor=262626"
             alt="npm version"
             class="h-6 rounded"
             loading="lazy"
           />
         </a>
         <a
-          href="https://www.npmjs.com/package/@mauricio.wolff/mcp-obsidian"
+          href="https://www.npmjs.com/package/mcpvault"
           target="_blank"
           rel="noopener noreferrer"
           class="transform hover:scale-105 transition-all duration-200 rounded hover:shadow-lg hover:shadow-accent/25"
         >
           <img
-            src="https://img.shields.io/npm/dt/@mauricio.wolff/mcp-obsidian?style=flat&logo=npm&logoColor=white&color=9065ea&labelColor=262626"
+            src="https://img.shields.io/npm/dt/mcpvault?style=flat&logo=npm&logoColor=white&color=9065ea&labelColor=262626"
             alt="npm downloads"
             class="h-6 rounded"
             loading="lazy"

--- a/website/src/components/HowItWorks.astro
+++ b/website/src/components/HowItWorks.astro
@@ -9,7 +9,7 @@ const examples = [
     description: 'Find notes and read their content for analysis',
     tags: ['Search', 'Read', 'Analysis'],
     prompt: 'Find my productivity notes and summarize the key concepts',
-    response: `MCP-Obsidian: Using search_notes...
+    response: `MCP-Vault: Using search_notes...
 
 Request:
 \`\`\`json
@@ -39,7 +39,7 @@ Response:
 ]
 \`\`\`
 
-MCP-Obsidian: Using read_multiple_notes...
+MCP-Vault: Using read_multiple_notes...
 
 Request:
 \`\`\`json
@@ -61,7 +61,7 @@ Done. I've analyzed the notes. Key concepts include:
     description: 'Batch update frontmatter across multiple notes',
     tags: ['Frontmatter', 'Batch Updates'],
     prompt: 'Mark all my project notes as completed',
-    response: `MCP-Obsidian: Using update_frontmatter...
+    response: `MCP-Vault: Using update_frontmatter...
 
 Request:
 \`\`\`json
@@ -90,7 +90,7 @@ Done. Updated 4 project notes with completion status`
         Usage Examples
       </h2>
       <p class="text-xl text-muted-foreground max-w-3xl mx-auto">
-        Practical prompts you can try with your AI assistant and MCP-Obsidian.
+        Practical prompts you can try with your AI assistant and MCP-Vault.
       </p>
     </div>
 
@@ -169,7 +169,7 @@ Done. Updated 4 project notes with completion status`
             Example Prompts
           </h3>
           <p class="text-muted-foreground mb-4">
-            Once MCP-Obsidian is set up, these prompts demonstrate search, read, and write operations in a single flow.
+            Once MCP-Vault is set up, these prompts demonstrate search, read, and write operations in a single flow.
           </p>
           <a
             href="/install"

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -42,7 +42,7 @@ function isActive(href: string) {
             </defs>
           </svg>
         </div>
-        <span class="text-xl font-bold text-foreground">MCP-Obsidian</span>
+        <span class="text-xl font-bold text-foreground">MCP-Vault</span>
         <span class="hidden sm:inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-accent/20 text-white border border-accent/30 leading-tight">v{pkg.version}</span>
       </a>
 
@@ -61,7 +61,7 @@ function isActive(href: string) {
             </span>
           </a>
         ))}
-        <a href="https://github.com/bitbonsai/mcp-obsidian" target="_blank" rel="noopener noreferrer" class="nav-link inline-flex items-center gap-1.5">
+        <a href="https://github.com/bitbonsai/mcpvault" target="_blank" rel="noopener noreferrer" class="nav-link inline-flex items-center gap-1.5">
           <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
           GitHub
         </a>
@@ -92,7 +92,7 @@ function isActive(href: string) {
           </span>
         </a>
       ))}
-      <a href="https://github.com/bitbonsai/mcp-obsidian" target="_blank" rel="noopener noreferrer" class="nav-link text-center text-lg flex items-center justify-center gap-2">
+      <a href="https://github.com/bitbonsai/mcpvault" target="_blank" rel="noopener noreferrer" class="nav-link text-center text-lg flex items-center justify-center gap-2">
         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         GitHub
       </a>

--- a/website/src/components/SkillsContent.astro
+++ b/website/src/components/SkillsContent.astro
@@ -146,7 +146,7 @@ const negativeTriggers = [
   'Web-based Obsidian Publish tasks',
 ];
 
-const installCmd = 'npx skills add bitbonsai/mcp-obsidian';
+const installCmd = 'npx skills add bitbonsai/mcpvault';
 ---
 
 <section class="relative py-24 px-4 sm:px-6 lg:px-8 bg-gradient-to-b from-background via-card/5 to-background">
@@ -595,7 +595,7 @@ metadata:
               Ready to get started?
             </h3>
             <p class="text-muted-foreground mb-4">
-              Install MCP-Obsidian and connect your vault to any AI assistant.
+              Install MCP-Vault and connect your vault to any AI assistant.
             </p>
             <a
               href="/install"

--- a/website/src/components/Terminal.astro
+++ b/website/src/components/Terminal.astro
@@ -24,7 +24,7 @@ import {
         Quick Install
       </h2>
       <p class="text-xl text-muted-foreground max-w-3xl mx-auto">
-        Get MCP-Obsidian running in seconds with any MCP-compatible platform
+        Get MCP-Vault running in seconds with any MCP-compatible platform
       </p>
     </div>
 
@@ -74,7 +74,7 @@ import {
             <div class="config-content" data-content="standard">
               <button
                 class="absolute top-4 right-4 p-2 hover:bg-card/50 rounded transition-colors copy-btn z-10"
-                data-copy='{"mcpServers": {"obsidian": {"command": "npx", "args": ["@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]}}}'
+                data-copy='{"mcpServers": {"obsidian": {"command": "npx", "args": ["mcpvault@latest", "/path/to/your/vault"]}}}'
                 title="Copy configuration"
                 aria-label="Copy configuration to clipboard"
               >
@@ -98,7 +98,7 @@ import {
   "mcpServers": {
     "obsidian": {
       "command": "npx",
-      "args": ["@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]
+      "args": ["mcpvault@latest", "/path/to/your/vault"]
     }
   }
 }`}
@@ -109,7 +109,7 @@ import {
             <div class="config-content hidden" data-content="claude-code">
               <button
                 class="absolute top-4 right-4 p-2 hover:bg-card/50 rounded transition-colors copy-btn z-10"
-                data-copy='claude mcp add-json obsidian --scope user &apos;{"type":"stdio","command":"npx","args":["@mauricio.wolff/mcp-obsidian@latest","/path/to/your/vault"]}&apos;'
+                data-copy='claude mcp add-json obsidian --scope user &apos;{"type":"stdio","command":"npx","args":["mcpvault@latest","/path/to/your/vault"]}&apos;'
                 title="Copy configuration"
                 aria-label="Copy configuration to clipboard"
               >
@@ -140,7 +140,7 @@ import {
                       class="font-mono text-sm code-scroll bg-background/50 rounded px-3 py-2"
                     >
                       <pre
-                        style="margin: 0; color: #cdd6f4; line-height: 1.5; white-space: nowrap;"><span style="color: #cba6f7;">claude</span> <span style="color: #89b4fa;">mcp add-json</span> <span style="color: #a6e3a1;">obsidian</span> <span style="color: #fab387;">--scope user</span> <span style="color: #f38ba8;">'&#123;"type":"stdio","command":"npx","args":["@mauricio.wolff/mcp-obsidian@latest","/path/to/your/vault"]&#125;'</span></pre>
+                        style="margin: 0; color: #cdd6f4; line-height: 1.5; white-space: nowrap;"><span style="color: #cba6f7;">claude</span> <span style="color: #89b4fa;">mcp add-json</span> <span style="color: #a6e3a1;">obsidian</span> <span style="color: #fab387;">--scope user</span> <span style="color: #f38ba8;">'&#123;"type":"stdio","command":"npx","args":["mcpvault@latest","/path/to/your/vault"]&#125;'</span></pre>
                     </div>
                   </div>
                 </div>
@@ -219,7 +219,7 @@ import {
                       opencode mcp add
                     </code>
                     <p class="text-xs text-muted-foreground mt-2">
-                      Interactive wizard — select <strong class="text-foreground">local</strong>, then enter the command: <code class="text-foreground">npx -y @mauricio.wolff/mcp-obsidian@latest /path/to/your/vault</code>
+                      Interactive wizard — select <strong class="text-foreground">local</strong>, then enter the command: <code class="text-foreground">npx -y mcpvault@latest /path/to/your/vault</code>
                     </p>
                   </div>
                 </div>
@@ -228,7 +228,7 @@ import {
               <p class="text-xs text-muted-foreground mt-4 mb-3">Or configure manually:</p>
               <button
                 class="absolute top-4 right-4 p-2 hover:bg-card/50 rounded transition-colors copy-btn z-10"
-                data-copy='{"$schema": "https://opencode.ai/config.json", "mcp": {"obsidian": {"type": "local", "command": ["npx", "-y", "@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]}}}'
+                data-copy='{"$schema": "https://opencode.ai/config.json", "mcp": {"obsidian": {"type": "local", "command": ["npx", "-y", "mcpvault@latest", "/path/to/your/vault"]}}}'
                 title="Copy configuration"
                 aria-label="Copy configuration to clipboard"
               >
@@ -253,7 +253,7 @@ import {
   "mcp": {
     "obsidian": {
       "type": "local",
-      "command": ["npx", "-y", "@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]
+      "command": ["npx", "-y", "mcpvault@latest", "/path/to/your/vault"]
     }
   }
 }`}
@@ -325,7 +325,7 @@ import {
                       Use the CLI
                     </p>
                     <code class="block bg-background/50 px-3 py-2 rounded text-foreground text-sm font-mono">
-                      gemini mcp add obsidian -- npx @mauricio.wolff/mcp-obsidian@latest /path/to/your/vault
+                      gemini mcp add obsidian -- npx mcpvault@latest /path/to/your/vault
                     </code>
                   </div>
                 </div>
@@ -334,7 +334,7 @@ import {
               <p class="text-xs text-muted-foreground mb-3">Or configure manually in <code class="text-foreground">~/.gemini/settings.json</code>:</p>
               <button
                 class="absolute top-4 right-4 p-2 hover:bg-card/50 rounded transition-colors copy-btn z-10"
-                data-copy='{"mcpServers": {"obsidian": {"command": "npx", "args": ["@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]}}}'
+                data-copy='{"mcpServers": {"obsidian": {"command": "npx", "args": ["mcpvault@latest", "/path/to/your/vault"]}}}'
                 title="Copy configuration"
                 aria-label="Copy configuration to clipboard"
               >
@@ -358,7 +358,7 @@ import {
   "mcpServers": {
     "obsidian": {
       "command": "npx",
-      "args": ["@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]
+      "args": ["mcpvault@latest", "/path/to/your/vault"]
     }
   }
 }`}
@@ -398,7 +398,7 @@ import {
                 class="absolute top-4 right-4 p-2 hover:bg-card/50 rounded transition-colors copy-btn z-10"
                 data-copy='[mcp_servers.obsidian]
 command = "npx"
-args = ["-y", "@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]'
+args = ["-y", "mcpvault@latest", "/path/to/your/vault"]'
                 title="Copy configuration"
                 aria-label="Copy configuration to clipboard"
               >
@@ -423,7 +423,7 @@ args = ["-y", "@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]'
                 <pre
                   style="margin: 0; color: #cdd6f4; line-height: 1.5;"><span style="color: #cba6f7;">[mcp_servers.obsidian]</span>
 <span style="color: #89b4fa;">command</span> <span style="color: #94e2d5;">=</span> <span style="color: #a6e3a1;">"npx"</span>
-<span style="color: #89b4fa;">args</span> <span style="color: #94e2d5;">=</span> <span style="color: #cdd6f4;">[</span><span style="color: #a6e3a1;">"-y"</span><span style="color: #cdd6f4;">,</span> <span style="color: #a6e3a1;">"@mauricio.wolff/mcp-obsidian@latest"</span><span style="color: #cdd6f4;">,</span> <span style="color: #a6e3a1;">"/path/to/your/vault"</span><span style="color: #cdd6f4;">]</span></pre>
+<span style="color: #89b4fa;">args</span> <span style="color: #94e2d5;">=</span> <span style="color: #cdd6f4;">[</span><span style="color: #a6e3a1;">"-y"</span><span style="color: #cdd6f4;">,</span> <span style="color: #a6e3a1;">"mcpvault@latest"</span><span style="color: #cdd6f4;">,</span> <span style="color: #a6e3a1;">"/path/to/your/vault"</span><span style="color: #cdd6f4;">]</span></pre>
               </div>
 
               <div
@@ -461,16 +461,16 @@ args = ["-y", "@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]'
             <Compass className="w-4 h-4 text-accent mt-0.5 flex-shrink-0" aria-hidden="true" />
             <span>
               <strong class="text-foreground">Optional no-path mode:</strong>
-              if your client starts MCP-Obsidian from inside your vault folder,
+              if your client starts MCP-Vault from inside your vault folder,
               you can omit the vault path and use current working directory.
             </span>
           </p>
           <div class="grid md:grid-cols-2 gap-2 text-xs">
             <code class="block bg-background/50 px-2 py-1 rounded text-foreground">
-              npx @mauricio.wolff/mcp-obsidian@latest
+              npx mcpvault@latest
             </code>
             <code class="block bg-background/50 px-2 py-1 rounded text-foreground">
-              "args": ["@mauricio.wolff/mcp-obsidian@latest"]
+              "args": ["mcpvault@latest"]
             </code>
           </div>
         </div>
@@ -658,11 +658,11 @@ args = ["-y", "@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]'
                 <p class="leading-relaxed">
                   You can omit the vault path entirely when your client starts this
                   server from inside your vault directory. In that case,
-                  MCP-Obsidian uses the current working directory as vault root.
+                  MCP-Vault uses the current working directory as vault root.
                 </p>
                 <div class="mt-3 space-y-2">
                   <code class="block bg-background/50 px-2 py-1 rounded text-foreground">
-                    npx @mauricio.wolff/mcp-obsidian@latest
+                    npx mcpvault@latest
                   </code>
                   <code class="block bg-background/50 px-2 py-1 rounded text-foreground">
                     npm start
@@ -727,17 +727,17 @@ args = ["-y", "@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]'
               </div>
 
               <div class="text-muted-foreground">
-                # Test MCP-Obsidian server
+                # Test MCP-Vault server
               </div>
               <div class="flex items-center gap-2">
                 <span class="text-accent">$</span>
                 <span class="text-foreground"
-                  >mcp-inspector npx @mauricio.wolff/mcp-obsidian@latest
+                  >mcp-inspector npx mcpvault@latest
                   /path/to/vault</span
                 >
                 <button
                   class="ml-auto p-1 hover:bg-card/50 rounded transition-colors copy-btn"
-                  data-copy="mcp-inspector npx @mauricio.wolff/mcp-obsidian@latest /path/to/vault"
+                  data-copy="mcp-inspector npx mcpvault@latest /path/to/vault"
                   title="Copy to clipboard"
                   aria-label="Copy test command to clipboard"
                 >
@@ -797,7 +797,7 @@ args = ["-y", "@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]'
                   clip-rule="evenodd"></path>
               </svg>
               <a
-                href="https://github.com/bitbonsai/mcp-obsidian"
+                href="https://github.com/bitbonsai/mcpvault"
                 target="_blank"
                 class="underline hover:text-foreground"
                 >View on GitHub for more details</a
@@ -876,7 +876,7 @@ args = ["-y", "@mauricio.wolff/mcp-obsidian@latest", "/path/to/your/vault"]'
             <h3 class="text-xl font-semibold text-success">You're all set!</h3>
           </div>
           <p class="text-muted-foreground mb-4">
-            Restart your AI platform and you'll see MCP-Obsidian connected. Your
+            Restart your AI platform and you'll see MCP-Vault connected. Your
             AI assistant can now safely read, search, and manage your Obsidian
             vault.
           </p>

--- a/website/src/components/UpdateCallout.astro
+++ b/website/src/components/UpdateCallout.astro
@@ -45,18 +45,18 @@ import { Rocket } from 'lucide-react';
           <div class="mb-4">
             <p class="text-muted-foreground leading-relaxed">
               <span class="font-medium text-foreground">v0.8.2 (March 2026):</span> Trailing-slash vault paths no longer truncate search results
-              (<a href="https://github.com/bitbonsai/mcp-obsidian/pull/48" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #48</a>),
+              (<a href="https://github.com/bitbonsai/mcpvault/pull/48" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #48</a>),
               <code>get_vault_stats</code> now handles dotted folder names correctly
-              (<a href="https://github.com/bitbonsai/mcp-obsidian/pull/42" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #42</a>),
+              (<a href="https://github.com/bitbonsai/mcpvault/pull/42" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #42</a>),
               note tools now support <code>.base</code> and <code>.canvas</code>
-              (<a href="https://github.com/bitbonsai/mcp-obsidian/pull/53" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #53</a>),
+              (<a href="https://github.com/bitbonsai/mcpvault/pull/53" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #53</a>),
               string frontmatter inputs are now handled safely
-              (<a href="https://github.com/bitbonsai/mcp-obsidian/pull/47" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #47</a>),
+              (<a href="https://github.com/bitbonsai/mcpvault/pull/47" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #47</a>),
               vault path is now optional for CLI usage (defaults to current working directory)
-              (<a href="https://github.com/bitbonsai/mcp-obsidian/issues/50" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">#50</a>),
+              (<a href="https://github.com/bitbonsai/mcpvault/issues/50" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">#50</a>),
               and dependency refreshes for the MCP SDK and Node types are merged
-              (<a href="https://github.com/bitbonsai/mcp-obsidian/pull/43" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #43</a>,
-              <a href="https://github.com/bitbonsai/mcp-obsidian/pull/44" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #44</a>)
+              (<a href="https://github.com/bitbonsai/mcpvault/pull/43" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #43</a>,
+              <a href="https://github.com/bitbonsai/mcpvault/pull/44" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #44</a>)
             </p>
           </div>
 
@@ -64,12 +64,12 @@ import { Rocket } from 'lucide-react';
             <ul class="text-muted-foreground space-y-2">
               <li>
                 <span class="font-medium text-foreground">v0.8.1:</span> Multi-word BM25 search relevance improvements
-                (<a href="https://github.com/bitbonsai/mcp-obsidian/pull/38" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #38</a>),
+                (<a href="https://github.com/bitbonsai/mcpvault/pull/38" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #38</a>),
                 patch_note undefined/null validation hardening
-                (<a href="https://github.com/bitbonsai/mcp-obsidian/pull/37" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #37</a>),
+                (<a href="https://github.com/bitbonsai/mcpvault/pull/37" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">PR #37</a>),
                 new <code>move_file</code> tool for binary-safe file moves with explicit path confirmation,
                 binary filenames now visible in directory listings
-                (<a href="https://github.com/bitbonsai/mcp-obsidian/issues/21" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">#21</a>)
+                (<a href="https://github.com/bitbonsai/mcpvault/issues/21" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">#21</a>)
               </li>
               <li>
                 <span class="font-medium text-foreground">v0.7.5:</span> Search now matches note filenames,
@@ -80,16 +80,16 @@ import { Rocket } from 'lucide-react';
               </li>
               <li>
                 <span class="font-medium text-foreground">v0.7.3:</span> Bug fix for folder detection with dots in names + dependency updates
-                <a href="https://github.com/bitbonsai/mcp-obsidian/pull/15" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">(PR #15)</a>
+                <a href="https://github.com/bitbonsai/mcpvault/pull/15" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">(PR #15)</a>
               </li>
               <li>
                 <span class="font-medium text-foreground">v0.7.2:</span> Security hardening - TOCTOU fixes, regex injection prevention, comprehensive CI/CD
-                <a href="https://github.com/bitbonsai/mcp-obsidian/pull/12" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">(PR #12)</a>
+                <a href="https://github.com/bitbonsai/mcpvault/pull/12" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">(PR #12)</a>
               </li>
             </ul>
 
             <a
-              href="https://github.com/bitbonsai/mcp-obsidian/blob/main/CHANGELOG.md"
+              href="https://github.com/bitbonsai/mcpvault/blob/main/CHANGELOG.md"
               target="_blank"
               rel="noopener noreferrer"
               class="updates-changelog-link"

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -10,13 +10,13 @@ export interface Props {
 }
 
 const {
-  title = "MCP-Obsidian - Universal AI Bridge for Obsidian Vaults",
+  title = "MCP-Vault - Universal AI Bridge for Obsidian Vaults",
   description = "Connect ANY AI assistant to your Obsidian vault with the open MCP standard. Works with Claude, ChatGPT, and future AI tools. Private, secure, and future-proof.",
-  image = "https://mcp-obsidian.org/og-image.jpg",
-  canonical = "https://mcp-obsidian.org"
+  image = "https://mcpvault.org/og-image.jpg",
+  canonical = "https://mcpvault.org"
 } = Astro.props;
 
-const fullTitle = title.includes("MCP-Obsidian") ? title : `${title} | MCP-Obsidian`;
+const fullTitle = title.includes("MCP-Vault") ? title : `${title} | MCP-Vault`;
 ---
 
 <!doctype html>
@@ -40,7 +40,7 @@ const fullTitle = title.includes("MCP-Obsidian") ? title : `${title} | MCP-Obsid
     <meta property="og:title" content={fullTitle} />
     <meta property="og:description" content={description} />
     <meta property="og:image" content={image} />
-    <meta property="og:site_name" content="MCP-Obsidian" />
+    <meta property="og:site_name" content="MCP-Vault" />
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
@@ -268,10 +268,10 @@ const fullTitle = title.includes("MCP-Obsidian") ? title : `${title} | MCP-Obsid
     <script is:inline type="application/ld+json" set:html={JSON.stringify({
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
-      "name": "MCP-Obsidian",
+      "name": "MCP-Vault",
       "description": "Universal AI bridge for Obsidian vaults using the Model Context Protocol. Connect any MCP-compatible AI assistant to your knowledge base.",
-      "url": "https://mcp-obsidian.org",
-      "downloadUrl": "https://www.npmjs.com/package/@mauricio.wolff/mcp-obsidian",
+      "url": "https://mcpvault.org",
+      "downloadUrl": "https://www.npmjs.com/package/mcpvault",
       "softwareVersion": pkg.version,
       "operatingSystem": ["macOS", "Windows", "Linux"],
       "applicationCategory": "DeveloperApplication",
@@ -290,7 +290,7 @@ const fullTitle = title.includes("MCP-Obsidian") ? title : `${title} | MCP-Obsid
         "name": "bitbonsai",
         "url": "https://github.com/bitbonsai"
       },
-      "codeRepository": "https://github.com/bitbonsai/mcp-obsidian"
+      "codeRepository": "https://github.com/bitbonsai/mcpvault"
     })}></script>
   </head>
   <body class="min-h-screen bg-background text-foreground antialiased relative pt-24">

--- a/website/src/pages/demo.astro
+++ b/website/src/pages/demo.astro
@@ -7,8 +7,8 @@ import Footer from '@components/Footer.astro';
 
 <Layout
   title="Demo"
-  description="See MCP-Obsidian in action. Interactive examples showing how AI assistants read, write, search, and manage your Obsidian vault."
-  canonical="https://mcp-obsidian.org/demo"
+  description="See MCP-Vault in action. Interactive examples showing how AI assistants read, write, search, and manage your Obsidian vault."
+  canonical="https://mcpvault.org/demo"
 >
   <Nav />
 

--- a/website/src/pages/features.astro
+++ b/website/src/pages/features.astro
@@ -9,8 +9,8 @@ import Footer from '@components/Footer.astro';
 
 <Layout
   title="Features"
-  description="Intelligent search, safe frontmatter handling, security-first design, and more. See how MCP-Obsidian compares to alternatives."
-  canonical="https://mcp-obsidian.org/features"
+  description="Intelligent search, safe frontmatter handling, security-first design, and more. See how MCP-Vault compares to alternatives."
+  canonical="https://mcpvault.org/features"
 >
   <Nav />
 

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -7,8 +7,8 @@ import Footer from '@components/Footer.astro';
 
 <Layout
   title="How It Works"
-  description="Practical usage examples showing how AI assistants interact with your Obsidian vault through MCP-Obsidian."
-  canonical="https://mcp-obsidian.org/how-it-works"
+  description="Practical usage examples showing how AI assistants interact with your Obsidian vault through MCP-Vault."
+  canonical="https://mcpvault.org/how-it-works"
 >
   <Nav />
 

--- a/website/src/pages/install.astro
+++ b/website/src/pages/install.astro
@@ -7,8 +7,8 @@ import Footer from '@components/Footer.astro';
 
 <Layout
   title="Install"
-  description="Get MCP-Obsidian running in seconds. Configuration for Claude Desktop, ChatGPT+, Claude Code, Gemini CLI, and more."
-  canonical="https://mcp-obsidian.org/install"
+  description="Get MCP-Vault running in seconds. Configuration for Claude Desktop, ChatGPT+, Claude Code, Gemini CLI, and more."
+  canonical="https://mcpvault.org/install"
 >
   <Nav />
 

--- a/website/src/pages/skill.astro
+++ b/website/src/pages/skill.astro
@@ -8,7 +8,7 @@ import Footer from '@components/Footer.astro';
 <Layout
   title="Skill"
   description="Obsidian skill combining MCP server tools with Obsidian CLI context. Routing, workflow patterns, and safety defaults."
-  canonical="https://mcp-obsidian.org/skill"
+  canonical="https://mcpvault.org/skill"
 >
   <Nav />
 


### PR DESCRIPTION
- Rename npm package from @mauricio.wolff/mcp-obsidian to mcpvault (Obsidian’s request)
- Update MCP server name to mcpvault, binary to mcpvault
- Update all domain references from mcp-obsidian.org to mcpvault.org
- Update product display name from MCP-Obsidian to MCP-Vault
- Update GitHub repo references to bitbonsai/mcpvault
- Add homepage field pointing to mcpvault.org
- Update JSON-LD schema, OG tags, and canonical URL in Layout.astro
- Update all website components, pages, and public markdown files
