### PR TITLE
chore: use @bitbonsai/mcpvault scoped package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,7 +241,7 @@ If you were using the Bun version, update your configuration:
 ```json
 {
   "command": "npx",
-  "args": ["mcpvault@latest", "/path/to/vault"]
+  "args": ["@bitbonsai/mcpvault@latest", "/path/to/vault"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ https://github.com/user-attachments/assets/657ac4c6-1cd2-4cc3-829f-fd095a32f71c
    If using the published package:
 
    ```bash
-   npx @modelcontextprotocol/inspector npx mcpvault@latest /path/to/your/vault
+   npx @modelcontextprotocol/inspector npx @bitbonsai/mcpvault@latest /path/to/your/vault
    ```
 
 3. **Configure your AI client:**
@@ -57,7 +57,7 @@ https://github.com/user-attachments/assets/657ac4c6-1cd2-4cc3-829f-fd095a32f71c
      "mcpServers": {
        "obsidian": {
          "command": "npx",
-         "args": ["mcpvault@latest", "/path/to/your/vault"]
+         "args": ["@bitbonsai/mcpvault@latest", "/path/to/your/vault"]
        }
      }
    }
@@ -70,7 +70,7 @@ https://github.com/user-attachments/assets/657ac4c6-1cd2-4cc3-829f-fd095a32f71c
      "mcpServers": {
        "obsidian": {
          "command": "npx",
-         "args": ["mcpvault@latest", "/path/to/your/vault"],
+         "args": ["@bitbonsai/mcpvault@latest", "/path/to/your/vault"],
          "env": {}
        }
      }
@@ -86,7 +86,7 @@ https://github.com/user-attachments/assets/657ac4c6-1cd2-4cc3-829f-fd095a32f71c
          "type": "local",
          "command": [
            "npx",
-           "mcpvault@latest",
+           "@bitbonsai/mcpvault@latest",
            "/path/to/your/vault/"
          ],
          "enabled": true
@@ -155,7 +155,7 @@ MCP is an open protocol. You're not tied to any specific vendor or platform. You
 No installation needed! Use `npx` to run directly:
 
 ```bash
-npx mcpvault@latest /path/to/your/obsidian/vault
+npx @bitbonsai/mcpvault@latest /path/to/your/obsidian/vault
 ```
 
 If you omit the vault path, the server uses your current working directory as the vault root.
@@ -188,7 +188,7 @@ npx @modelcontextprotocol/inspector npm start /path/to/your/vault
 npm install -g @modelcontextprotocol/inspector
 
 # Test with any vault
-mcp-inspector npx mcpvault@latest /path/to/your/vault
+mcp-inspector npx @bitbonsai/mcpvault@latest /path/to/your/vault
 ```
 
 ## Usage
@@ -198,9 +198,9 @@ mcp-inspector npx mcpvault@latest /path/to/your/vault
 **End users:**
 
 ```bash
-npx mcpvault@latest
-npx mcpvault@latest /path/to/your/obsidian/vault
-npx mcpvault@latest ./Vault
+npx @bitbonsai/mcpvault@latest
+npx @bitbonsai/mcpvault@latest /path/to/your/obsidian/vault
+npx @bitbonsai/mcpvault@latest ./Vault
 ```
 
 **Developers:**
@@ -225,7 +225,7 @@ Add to your Claude Desktop configuration file:
     "obsidian": {
       "command": "npx",
       "args": [
-        "mcpvault@latest",
+        "@bitbonsai/mcpvault@latest",
         "/Users/yourname/Documents/MyVault"
       ]
     }
@@ -241,14 +241,14 @@ Add to your Claude Desktop configuration file:
     "obsidian-personal": {
       "command": "npx",
       "args": [
-        "mcpvault@latest",
+        "@bitbonsai/mcpvault@latest",
         "/Users/yourname/Documents/PersonalVault"
       ]
     },
     "obsidian-work": {
       "command": "npx",
       "args": [
-        "mcpvault@latest",
+        "@bitbonsai/mcpvault@latest",
         "/Users/yourname/Documents/WorkVault"
       ]
     }
@@ -288,7 +288,7 @@ Edit `~/.claude.json`:
   "mcpServers": {
     "obsidian": {
       "command": "npx",
-      "args": ["mcpvault@latest", "/path/to/your/vault"],
+      "args": ["@bitbonsai/mcpvault@latest", "/path/to/your/vault"],
       "env": {}
     }
   }
@@ -305,7 +305,7 @@ Edit `.claude.json` in your project or add to the projects section:
       "mcpServers": {
         "obsidian": {
           "command": "npx",
-          "args": ["mcpvault@latest", "/path/to/your/vault"]
+          "args": ["@bitbonsai/mcpvault@latest", "/path/to/your/vault"]
         }
       }
     }
@@ -316,7 +316,7 @@ Edit `.claude.json` in your project or add to the projects section:
 **Using Claude Code CLI:**
 
 ```bash
-claude mcp add obsidian --scope user npx mcpvault /path/to/your/vault
+claude mcp add obsidian --scope user npx @bitbonsai/mcpvault /path/to/your/vault
 ```
 
 #### Goose Desktop
@@ -324,7 +324,7 @@ claude mcp add obsidian --scope user npx mcpvault /path/to/your/vault
 On Goose Desktop settings, click **Add custom extension**, and on the command field add:
 
 ```bash
-npx mcpvault@latest /path/to/your/vault
+npx @bitbonsai/mcpvault@latest /path/to/your/vault
 ```
 
 #### Other MCP-Compatible Clients (2025)
@@ -372,7 +372,7 @@ Most modern MCP clients use similar JSON configuration patterns. Refer to your s
 #### "command not found: npx"
 
 - **Solution:** Install Node.js runtime from [nodejs.org](https://nodejs.org)
-- **Alternative:** Use global install: `npm install -g mcpvault`
+- **Alternative:** Use global install: `npm install -g @bitbonsai/mcpvault`
 
 #### "File not found" when paths look correct
 
@@ -407,7 +407,7 @@ Most modern MCP clients use similar JSON configuration patterns. Refer to your s
 Run with error logging:
 
 ```bash
-npx mcpvault /path/to/vault 2>debug.log
+npx @bitbonsai/mcpvault /path/to/vault 2>debug.log
 ```
 
 ### Getting Help

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mcpvault",
+  "name": "@bitbonsai/mcpvault",
   "version": "0.8.2",
   "description": "Universal AI bridge for Obsidian vaults - connect any MCP-compatible assistant",
   "homepage": "https://mcpvault.org",

--- a/server.ts
+++ b/server.ts
@@ -38,7 +38,7 @@ mcpvault v${VERSION}
 Universal AI bridge for Obsidian vaults - connect any MCP-compatible assistant
 
 Usage:
-  npx mcpvault [vault-path]
+  npx @bitbonsai/mcpvault [vault-path]
 
 Arguments:
   [vault-path]    Optional path to your Obsidian vault directory
@@ -49,11 +49,11 @@ Options:
   --help, -h      Show this help message
 
 Examples:
-  npx mcpvault
-  npx mcpvault ~/Documents/MyVault
-  npx mcpvault ./Vault
-  npx mcpvault /path/to/obsidian/vault
-  npx mcpvault "/path/with spaces/Obsidian Vault"
+  npx @bitbonsai/mcpvault
+  npx @bitbonsai/mcpvault ~/Documents/MyVault
+  npx @bitbonsai/mcpvault ./Vault
+  npx @bitbonsai/mcpvault /path/to/obsidian/vault
+  npx @bitbonsai/mcpvault "/path/with spaces/Obsidian Vault"
 `);
   process.exit(0);
 }

--- a/website/public/install.md
+++ b/website/public/install.md
@@ -13,7 +13,7 @@ Add to your MCP configuration file:
   "mcpServers": {
     "obsidian": {
       "command": "npx",
-      "args": ["mcpvault@latest", "/path/to/your/vault"]
+      "args": ["@bitbonsai/mcpvault@latest", "/path/to/your/vault"]
     }
   }
 }
@@ -22,7 +22,7 @@ Add to your MCP configuration file:
 ### Claude Code
 
 ```bash
-claude mcp add-json obsidian --scope user '{"type":"stdio","command":"npx","args":["mcpvault@latest","/path/to/your/vault"]}'
+claude mcp add-json obsidian --scope user '{"type":"stdio","command":"npx","args":["@bitbonsai/mcpvault@latest","/path/to/your/vault"]}'
 ```
 
 **Configuration Scopes:**
@@ -38,7 +38,7 @@ claude mcp add-json obsidian --scope user '{"type":"stdio","command":"npx","args
 opencode mcp add
 ```
 
-Select **local**, then enter the command: `npx -y mcpvault@latest /path/to/your/vault`
+Select **local**, then enter the command: `npx -y @bitbonsai/mcpvault@latest /path/to/your/vault`
 
 **Option 2: Config file**
 
@@ -50,7 +50,7 @@ Add to your `opencode.json` (project root) or `~/.config/opencode/opencode.json`
   "mcp": {
     "obsidian": {
       "type": "local",
-      "command": ["npx", "-y", "mcpvault@latest", "/path/to/your/vault"]
+      "command": ["npx", "-y", "@bitbonsai/mcpvault@latest", "/path/to/your/vault"]
     }
   }
 }
@@ -61,7 +61,7 @@ Add to your `opencode.json` (project root) or `~/.config/opencode/opencode.json`
 **Option 1: CLI**
 
 ```bash
-gemini mcp add obsidian -- npx mcpvault@latest /path/to/your/vault
+gemini mcp add obsidian -- npx @bitbonsai/mcpvault@latest /path/to/your/vault
 ```
 
 **Option 2: Config file**
@@ -73,7 +73,7 @@ Add to `~/.gemini/settings.json`:
   "mcpServers": {
     "obsidian": {
       "command": "npx",
-      "args": ["mcpvault@latest", "/path/to/your/vault"]
+      "args": ["@bitbonsai/mcpvault@latest", "/path/to/your/vault"]
     }
   }
 }
@@ -84,7 +84,7 @@ Add to `~/.gemini/settings.json`:
 ```toml
 [mcp_servers.obsidian]
 command = "npx"
-args = ["-y", "mcpvault@latest", "/path/to/your/vault"]
+args = ["-y", "@bitbonsai/mcpvault@latest", "/path/to/your/vault"]
 ```
 
 ### Optional no-path mode (uses current directory)
@@ -92,11 +92,11 @@ args = ["-y", "mcpvault@latest", "/path/to/your/vault"]
 If your client launches MCP-Vault from inside your vault folder, you can omit the vault path.
 
 ```bash
-npx mcpvault@latest
+npx @bitbonsai/mcpvault@latest
 ```
 
 ```json
-"args": ["mcpvault@latest"]
+"args": ["@bitbonsai/mcpvault@latest"]
 ```
 
 Supported note file types: `.md`, `.markdown`, `.txt`, `.base`, `.canvas`.
@@ -136,7 +136,7 @@ No pre-installation needed! npx automatically downloads and runs the server.
 
 ```bash
 npm install -g @modelcontextprotocol/inspector
-mcp-inspector npx mcpvault@latest /path/to/vault
+mcp-inspector npx @bitbonsai/mcpvault@latest /path/to/vault
 ```
 
 Opens interactive web interface at http://localhost:5173 for testing all MCP methods.

--- a/website/src/components/CodeExample.astro
+++ b/website/src/components/CodeExample.astro
@@ -82,7 +82,7 @@ import { FolderOpen, Settings, Target, Zap } from 'lucide-react';
   "mcpServers": &#123;
     "obsidian": &#123;
       "command": "npx",
-      "args": ["mcpvault@latest", "/Users/you/Documents/MyVault"]
+      "args": ["@bitbonsai/mcpvault@latest", "/Users/you/Documents/MyVault"]
     &#125;
   &#125;
 &#125;</code></pre>
@@ -136,7 +136,7 @@ import { FolderOpen, Settings, Target, Zap } from 'lucide-react';
     "obsidian": &#123;
       "command": "npx",
       "args": [
-        "mcpvault@latest",
+        "@bitbonsai/mcpvault@latest",
         "/Users/you/Documents/MyVault",
         "--log-level", "debug",
         "--max-search-results", "50",
@@ -199,16 +199,16 @@ import { FolderOpen, Settings, Target, Zap } from 'lucide-react';
   "mcpServers": &#123;
     "obsidian-work": &#123;
       "command": "npx",
-      "args": ["mcpvault@latest", "/Users/you/Work/Notes"]
+      "args": ["@bitbonsai/mcpvault@latest", "/Users/you/Work/Notes"]
     &#125;,
     "obsidian-personal": &#123;
       "command": "npx",
-      "args": ["mcpvault@latest", "/Users/you/Personal/Journal"]
+      "args": ["@bitbonsai/mcpvault@latest", "/Users/you/Personal/Journal"]
     &#125;,
     "obsidian-research": &#123;
       "command": "npx",
       "args": [
-        "mcpvault@latest",
+        "@bitbonsai/mcpvault@latest",
         "/Users/you/Research/Papers",
         "--read-only", "true"
       ]
@@ -265,7 +265,7 @@ import { FolderOpen, Settings, Target, Zap } from 'lucide-react';
     "obsidian": &#123;
       "command": "npx",
       "args": [
-        "mcpvault@latest",
+        "@bitbonsai/mcpvault@latest",
         "/Users/you/Documents/MyVault",
         "--include-patterns", "*.md,!private/**",
         "--exclude-tags", "personal,draft",

--- a/website/src/components/Terminal.astro
+++ b/website/src/components/Terminal.astro
@@ -74,7 +74,7 @@ import {
             <div class="config-content" data-content="standard">
               <button
                 class="absolute top-4 right-4 p-2 hover:bg-card/50 rounded transition-colors copy-btn z-10"
-                data-copy='{"mcpServers": {"obsidian": {"command": "npx", "args": ["mcpvault@latest", "/path/to/your/vault"]}}}'
+                data-copy='{"mcpServers": {"obsidian": {"command": "npx", "args": ["@bitbonsai/mcpvault@latest", "/path/to/your/vault"]}}}'
                 title="Copy configuration"
                 aria-label="Copy configuration to clipboard"
               >
@@ -98,7 +98,7 @@ import {
   "mcpServers": {
     "obsidian": {
       "command": "npx",
-      "args": ["mcpvault@latest", "/path/to/your/vault"]
+      "args": ["@bitbonsai/mcpvault@latest", "/path/to/your/vault"]
     }
   }
 }`}
@@ -109,7 +109,7 @@ import {
             <div class="config-content hidden" data-content="claude-code">
               <button
                 class="absolute top-4 right-4 p-2 hover:bg-card/50 rounded transition-colors copy-btn z-10"
-                data-copy='claude mcp add-json obsidian --scope user &apos;{"type":"stdio","command":"npx","args":["mcpvault@latest","/path/to/your/vault"]}&apos;'
+                data-copy='claude mcp add-json obsidian --scope user &apos;{"type":"stdio","command":"npx","args":["@bitbonsai/mcpvault@latest","/path/to/your/vault"]}&apos;'
                 title="Copy configuration"
                 aria-label="Copy configuration to clipboard"
               >
@@ -140,7 +140,7 @@ import {
                       class="font-mono text-sm code-scroll bg-background/50 rounded px-3 py-2"
                     >
                       <pre
-                        style="margin: 0; color: #cdd6f4; line-height: 1.5; white-space: nowrap;"><span style="color: #cba6f7;">claude</span> <span style="color: #89b4fa;">mcp add-json</span> <span style="color: #a6e3a1;">obsidian</span> <span style="color: #fab387;">--scope user</span> <span style="color: #f38ba8;">'&#123;"type":"stdio","command":"npx","args":["mcpvault@latest","/path/to/your/vault"]&#125;'</span></pre>
+                        style="margin: 0; color: #cdd6f4; line-height: 1.5; white-space: nowrap;"><span style="color: #cba6f7;">claude</span> <span style="color: #89b4fa;">mcp add-json</span> <span style="color: #a6e3a1;">obsidian</span> <span style="color: #fab387;">--scope user</span> <span style="color: #f38ba8;">'&#123;"type":"stdio","command":"npx","args":["@bitbonsai/mcpvault@latest","/path/to/your/vault"]&#125;'</span></pre>
                     </div>
                   </div>
                 </div>
@@ -219,7 +219,7 @@ import {
                       opencode mcp add
                     </code>
                     <p class="text-xs text-muted-foreground mt-2">
-                      Interactive wizard — select <strong class="text-foreground">local</strong>, then enter the command: <code class="text-foreground">npx -y mcpvault@latest /path/to/your/vault</code>
+                      Interactive wizard — select <strong class="text-foreground">local</strong>, then enter the command: <code class="text-foreground">npx -y @bitbonsai/mcpvault@latest /path/to/your/vault</code>
                     </p>
                   </div>
                 </div>
@@ -228,7 +228,7 @@ import {
               <p class="text-xs text-muted-foreground mt-4 mb-3">Or configure manually:</p>
               <button
                 class="absolute top-4 right-4 p-2 hover:bg-card/50 rounded transition-colors copy-btn z-10"
-                data-copy='{"$schema": "https://opencode.ai/config.json", "mcp": {"obsidian": {"type": "local", "command": ["npx", "-y", "mcpvault@latest", "/path/to/your/vault"]}}}'
+                data-copy='{"$schema": "https://opencode.ai/config.json", "mcp": {"obsidian": {"type": "local", "command": ["npx", "-y", "@bitbonsai/mcpvault@latest", "/path/to/your/vault"]}}}'
                 title="Copy configuration"
                 aria-label="Copy configuration to clipboard"
               >
@@ -253,7 +253,7 @@ import {
   "mcp": {
     "obsidian": {
       "type": "local",
-      "command": ["npx", "-y", "mcpvault@latest", "/path/to/your/vault"]
+      "command": ["npx", "-y", "@bitbonsai/mcpvault@latest", "/path/to/your/vault"]
     }
   }
 }`}
@@ -325,7 +325,7 @@ import {
                       Use the CLI
                     </p>
                     <code class="block bg-background/50 px-3 py-2 rounded text-foreground text-sm font-mono">
-                      gemini mcp add obsidian -- npx mcpvault@latest /path/to/your/vault
+                      gemini mcp add obsidian -- npx @bitbonsai/mcpvault@latest /path/to/your/vault
                     </code>
                   </div>
                 </div>
@@ -334,7 +334,7 @@ import {
               <p class="text-xs text-muted-foreground mb-3">Or configure manually in <code class="text-foreground">~/.gemini/settings.json</code>:</p>
               <button
                 class="absolute top-4 right-4 p-2 hover:bg-card/50 rounded transition-colors copy-btn z-10"
-                data-copy='{"mcpServers": {"obsidian": {"command": "npx", "args": ["mcpvault@latest", "/path/to/your/vault"]}}}'
+                data-copy='{"mcpServers": {"obsidian": {"command": "npx", "args": ["@bitbonsai/mcpvault@latest", "/path/to/your/vault"]}}}'
                 title="Copy configuration"
                 aria-label="Copy configuration to clipboard"
               >
@@ -358,7 +358,7 @@ import {
   "mcpServers": {
     "obsidian": {
       "command": "npx",
-      "args": ["mcpvault@latest", "/path/to/your/vault"]
+      "args": ["@bitbonsai/mcpvault@latest", "/path/to/your/vault"]
     }
   }
 }`}
@@ -398,7 +398,7 @@ import {
                 class="absolute top-4 right-4 p-2 hover:bg-card/50 rounded transition-colors copy-btn z-10"
                 data-copy='[mcp_servers.obsidian]
 command = "npx"
-args = ["-y", "mcpvault@latest", "/path/to/your/vault"]'
+args = ["-y", "@bitbonsai/mcpvault@latest", "/path/to/your/vault"]'
                 title="Copy configuration"
                 aria-label="Copy configuration to clipboard"
               >
@@ -423,7 +423,7 @@ args = ["-y", "mcpvault@latest", "/path/to/your/vault"]'
                 <pre
                   style="margin: 0; color: #cdd6f4; line-height: 1.5;"><span style="color: #cba6f7;">[mcp_servers.obsidian]</span>
 <span style="color: #89b4fa;">command</span> <span style="color: #94e2d5;">=</span> <span style="color: #a6e3a1;">"npx"</span>
-<span style="color: #89b4fa;">args</span> <span style="color: #94e2d5;">=</span> <span style="color: #cdd6f4;">[</span><span style="color: #a6e3a1;">"-y"</span><span style="color: #cdd6f4;">,</span> <span style="color: #a6e3a1;">"mcpvault@latest"</span><span style="color: #cdd6f4;">,</span> <span style="color: #a6e3a1;">"/path/to/your/vault"</span><span style="color: #cdd6f4;">]</span></pre>
+<span style="color: #89b4fa;">args</span> <span style="color: #94e2d5;">=</span> <span style="color: #cdd6f4;">[</span><span style="color: #a6e3a1;">"-y"</span><span style="color: #cdd6f4;">,</span> <span style="color: #a6e3a1;">"@bitbonsai/mcpvault@latest"</span><span style="color: #cdd6f4;">,</span> <span style="color: #a6e3a1;">"/path/to/your/vault"</span><span style="color: #cdd6f4;">]</span></pre>
               </div>
 
               <div
@@ -467,10 +467,10 @@ args = ["-y", "mcpvault@latest", "/path/to/your/vault"]'
           </p>
           <div class="grid md:grid-cols-2 gap-2 text-xs">
             <code class="block bg-background/50 px-2 py-1 rounded text-foreground">
-              npx mcpvault@latest
+              npx @bitbonsai/mcpvault@latest
             </code>
             <code class="block bg-background/50 px-2 py-1 rounded text-foreground">
-              "args": ["mcpvault@latest"]
+              "args": ["@bitbonsai/mcpvault@latest"]
             </code>
           </div>
         </div>
@@ -662,7 +662,7 @@ args = ["-y", "mcpvault@latest", "/path/to/your/vault"]'
                 </p>
                 <div class="mt-3 space-y-2">
                   <code class="block bg-background/50 px-2 py-1 rounded text-foreground">
-                    npx mcpvault@latest
+                    npx @bitbonsai/mcpvault@latest
                   </code>
                   <code class="block bg-background/50 px-2 py-1 rounded text-foreground">
                     npm start
@@ -732,12 +732,12 @@ args = ["-y", "mcpvault@latest", "/path/to/your/vault"]'
               <div class="flex items-center gap-2">
                 <span class="text-accent">$</span>
                 <span class="text-foreground"
-                  >mcp-inspector npx mcpvault@latest
+                  >mcp-inspector npx @bitbonsai/mcpvault@latest
                   /path/to/vault</span
                 >
                 <button
                   class="ml-auto p-1 hover:bg-card/50 rounded transition-colors copy-btn"
-                  data-copy="mcp-inspector npx mcpvault@latest /path/to/vault"
+                  data-copy="mcp-inspector npx @bitbonsai/mcpvault@latest /path/to/vault"
                   title="Copy to clipboard"
                   aria-label="Copy test command to clipboard"
                 >


### PR DESCRIPTION
npm rejected unscoped 'mcpvault' as too similar to existing 'mcp-vault' package.