### PR TITLE
feat: add active_file, active_folder, and open tools (Obsidian CLI)

### DIFF
--- a/src/active.test.ts
+++ b/src/active.test.ts
@@ -1,0 +1,313 @@
+import { test, expect, beforeEach, afterEach, describe } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { handleActiveFile, handleActiveFolder, handleOpen } from "./active.js";
+import { FrontmatterHandler } from "./frontmatter.js";
+import { FileSystemService } from "./filesystem.js";
+import type { VaultAppProvider } from "./vault-app-provider.js";
+
+// --- Mock VaultAppProvider ---
+
+interface MockOptions {
+  fileInfo?: Record<string, string | number>;
+  fileContent?: string;
+  running?: boolean;
+  noActiveFile?: boolean;
+}
+
+const DEFAULT_FILE_INFO: Record<string, string | number> = {
+  path: "Notes/example.md",
+  name: "example",
+  extension: "md",
+  size: 1234,
+  created: 1700000000000,
+  modified: 1700000001000,
+};
+
+const DEFAULT_FILE_CONTENT = `---
+title: Example
+tags:
+  - test
+status: draft
+---
+
+# Example Note
+
+Some content here.
+`;
+
+class MockVaultAppProvider implements VaultAppProvider {
+  private readonly fileInfo: Record<string, string | number>;
+  private readonly fileContent: string;
+  private readonly running: boolean;
+  private readonly noActiveFile: boolean;
+
+  constructor(options?: MockOptions) {
+    this.fileInfo = options?.fileInfo ?? DEFAULT_FILE_INFO;
+    this.fileContent = options?.fileContent ?? DEFAULT_FILE_CONTENT;
+    this.running = options?.running ?? true;
+    this.noActiveFile = options?.noActiveFile ?? false;
+  }
+
+  async getActiveFileInfo(): Promise<Record<string, string | number>> {
+    if (!this.running) throw new Error("Obsidian is not running. Start Obsidian and retry.");
+    if (this.noActiveFile) throw new Error("No active file. Open a file in Obsidian and retry.");
+    return { ...this.fileInfo };
+  }
+
+  async readActiveFileContent(): Promise<string> {
+    if (!this.running) throw new Error("Obsidian is not running. Start Obsidian and retry.");
+    return this.fileContent;
+  }
+
+  async isRunning(): Promise<boolean> {
+    return this.running;
+  }
+
+  async ensureRunning(): Promise<void> {
+    if (!this.running) throw new Error("Obsidian is not running. Start Obsidian and retry.");
+  }
+
+  async openFile(_path: string, _options?: { newtab?: boolean }): Promise<string> {
+    if (!this.running) throw new Error("Obsidian is not running. Start Obsidian and retry.");
+    return "";
+  }
+}
+
+// --- Helpers ---
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }): Record<string, unknown> {
+  return JSON.parse(result.content[0]!.text);
+}
+
+const frontmatterHandler = new FrontmatterHandler();
+
+// --- active_file tests ---
+
+describe("active_file", () => {
+  test("returns metadata and content by default", async () => {
+    const mock = new MockVaultAppProvider();
+    const result = await handleActiveFile(mock, frontmatterHandler, {});
+    const data = parseResult(result);
+
+    expect(data.path).toBe("Notes/example.md");
+    expect(data.name).toBe("example");
+    expect(data.extension).toBe("md");
+    expect(data.content).toContain("# Example Note");
+  });
+
+  test("omits content when include_content is false", async () => {
+    const mock = new MockVaultAppProvider();
+    const result = await handleActiveFile(mock, frontmatterHandler, { include_content: false });
+    const data = parseResult(result);
+
+    expect(data.path).toBe("Notes/example.md");
+    expect(data.content).toBeUndefined();
+  });
+
+  test("returns parsed frontmatter and content with parse_frontmatter", async () => {
+    const mock = new MockVaultAppProvider();
+    const result = await handleActiveFile(mock, frontmatterHandler, { parse_frontmatter: true });
+    const data = parseResult(result);
+
+    expect(data.path).toBe("Notes/example.md");
+    expect(data.fm).toBeDefined();
+    const fm = data.fm as Record<string, unknown>;
+    expect(fm.title).toBe("Example");
+    expect(fm.tags).toEqual(["test"]);
+    expect(fm.status).toBe("draft");
+    expect(data.content).toContain("# Example Note");
+    // Content should not include frontmatter fences
+    expect(data.content as string).not.toContain("---\ntitle:");
+  });
+
+  test("returns only frontmatter with frontmatter_only", async () => {
+    const mock = new MockVaultAppProvider();
+    const result = await handleActiveFile(mock, frontmatterHandler, { frontmatter_only: true });
+    const data = parseResult(result);
+
+    expect(data.path).toBe("Notes/example.md");
+    expect(data.fm).toBeDefined();
+    const fm = data.fm as Record<string, unknown>;
+    expect(fm.title).toBe("Example");
+    // Should NOT have content field
+    expect(data.content).toBeUndefined();
+  });
+
+  test("rejects parse_frontmatter + frontmatter_only together", async () => {
+    const mock = new MockVaultAppProvider();
+    await expect(
+      handleActiveFile(mock, frontmatterHandler, {
+        parse_frontmatter: true,
+        frontmatter_only: true,
+      }),
+    ).rejects.toThrow("Cannot specify both");
+  });
+
+  test("throws when app is not running", async () => {
+    const mock = new MockVaultAppProvider({ running: false });
+    await expect(
+      handleActiveFile(mock, frontmatterHandler, {}),
+    ).rejects.toThrow("Obsidian is not running");
+  });
+
+  test("throws when no active file", async () => {
+    const mock = new MockVaultAppProvider({ noActiveFile: true });
+    await expect(
+      handleActiveFile(mock, frontmatterHandler, {}),
+    ).rejects.toThrow("No active file");
+  });
+
+  test("handles non-markdown file content", async () => {
+    const mock = new MockVaultAppProvider({
+      fileInfo: { path: "data.csv", name: "data", extension: "csv", size: 50 },
+      fileContent: "col1,col2\nval1,val2\n",
+    });
+    const result = await handleActiveFile(mock, frontmatterHandler, {});
+    const data = parseResult(result);
+
+    expect(data.path).toBe("data.csv");
+    expect(data.content).toBe("col1,col2\nval1,val2\n");
+  });
+
+  test("handles parse_frontmatter on content without frontmatter", async () => {
+    const mock = new MockVaultAppProvider({
+      fileContent: "Just plain text, no frontmatter.",
+    });
+    const result = await handleActiveFile(mock, frontmatterHandler, { parse_frontmatter: true });
+    const data = parseResult(result);
+
+    expect(data.fm).toBeDefined();
+    expect(data.content).toBeDefined();
+  });
+});
+
+// --- active_folder tests ---
+
+describe("active_folder", () => {
+  let testVaultPath: string;
+  let fileSystem: FileSystemService;
+
+  beforeEach(async () => {
+    testVaultPath = await mkdtemp(join(tmpdir(), "mcpvault-test-"));
+    fileSystem = new FileSystemService(testVaultPath);
+  });
+
+  afterEach(async () => {
+    await rm(testVaultPath, { recursive: true });
+  });
+
+  test("returns folder path and active file", async () => {
+    const mock = new MockVaultAppProvider();
+    const result = await handleActiveFolder(mock, fileSystem, { include_files: false });
+    const data = parseResult(result);
+
+    expect(data.dir).toBe("Notes");
+    expect(data.active).toBe("Notes/example.md");
+    expect(data.files).toBeUndefined();
+  });
+
+  test("returns file listing when directory exists", async () => {
+    await mkdir(join(testVaultPath, "Notes"), { recursive: true });
+    await writeFile(join(testVaultPath, "Notes/example.md"), "# Example");
+    await writeFile(join(testVaultPath, "Notes/other.md"), "# Other");
+
+    const mock = new MockVaultAppProvider();
+    const result = await handleActiveFolder(mock, fileSystem, {});
+    const data = parseResult(result);
+
+    expect(data.dir).toBe("Notes");
+    expect(data.active).toBe("Notes/example.md");
+    expect(data.files).toContain("example.md");
+    expect(data.files).toContain("other.md");
+  });
+
+  test("omits file list when include_files is false", async () => {
+    const mock = new MockVaultAppProvider();
+    const result = await handleActiveFolder(mock, fileSystem, { include_files: false });
+    const data = parseResult(result);
+
+    expect(data.dir).toBe("Notes");
+    expect(data.active).toBe("Notes/example.md");
+    expect(data.files).toBeUndefined();
+  });
+
+  test("throws when app is not running", async () => {
+    const mock = new MockVaultAppProvider({ running: false });
+    await expect(
+      handleActiveFolder(mock, fileSystem, {}),
+    ).rejects.toThrow("Obsidian is not running");
+  });
+
+  test("throws when no active file", async () => {
+    const mock = new MockVaultAppProvider({ noActiveFile: true });
+    await expect(
+      handleActiveFolder(mock, fileSystem, {}),
+    ).rejects.toThrow("No active file");
+  });
+
+  test("handles vault root file (folder = '.')", async () => {
+    const mock = new MockVaultAppProvider({
+      fileInfo: { path: "root-note.md", name: "root-note", extension: "md", size: 100 },
+    });
+    const result = await handleActiveFolder(mock, fileSystem, { include_files: false });
+    const data = parseResult(result);
+
+    expect(data.dir).toBe(".");
+    expect(data.active).toBe("root-note.md");
+  });
+});
+
+// --- open tests ---
+
+describe("open", () => {
+  test("opens a file and returns the path", async () => {
+    const mock = new MockVaultAppProvider();
+    const result = await handleOpen(mock, { path: "Notes/example.md" });
+    const data = parseResult(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(data.opened).toBe("Notes/example.md");
+    expect(data.newtab).toBe(true);
+  });
+
+  test("opens a file with newtab explicitly true", async () => {
+    const mock = new MockVaultAppProvider();
+    const result = await handleOpen(mock, { path: "Notes/example.md", newtab: true });
+    const data = parseResult(result);
+
+    expect(data.opened).toBe("Notes/example.md");
+    expect(data.newtab).toBe(true);
+  });
+
+  test("opens a file with newtab false", async () => {
+    const mock = new MockVaultAppProvider();
+    const result = await handleOpen(mock, { path: "Notes/example.md", newtab: false });
+    const data = parseResult(result);
+
+    expect(data.opened).toBe("Notes/example.md");
+    expect(data.newtab).toBe(false);
+  });
+
+  test("throws when Obsidian is not running", async () => {
+    const mock = new MockVaultAppProvider({ running: false });
+    await expect(
+      handleOpen(mock, { path: "Notes/example.md" }),
+    ).rejects.toThrow("Obsidian is not running");
+  });
+
+  test("throws for empty path", async () => {
+    const mock = new MockVaultAppProvider();
+    await expect(
+      handleOpen(mock, { path: "" }),
+    ).rejects.toThrow("path is required");
+  });
+
+  test("throws for whitespace-only path", async () => {
+    const mock = new MockVaultAppProvider();
+    await expect(
+      handleOpen(mock, { path: "   " }),
+    ).rejects.toThrow("path is required");
+  });
+});

--- a/src/active.ts
+++ b/src/active.ts
@@ -1,0 +1,114 @@
+import { dirname } from "node:path";
+import type { VaultAppProvider } from "./vault-app-provider.js";
+import type { FrontmatterHandler } from "./frontmatter.js";
+import type { FileSystemService } from "./filesystem.js";
+
+interface ToolResponse {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+  [key: string]: unknown;
+}
+
+export async function handleActiveFile(
+  vaultApp: VaultAppProvider,
+  frontmatterHandler: FrontmatterHandler,
+  args: {
+    include_content?: boolean;
+    parse_frontmatter?: boolean;
+    frontmatter_only?: boolean;
+    prettyPrint?: boolean;
+  },
+): Promise<ToolResponse> {
+  await vaultApp.ensureRunning();
+
+  if (args.parse_frontmatter && args.frontmatter_only) {
+    throw new Error(
+      "Cannot specify both parse_frontmatter and frontmatter_only — use one or the other",
+    );
+  }
+
+  const info = await vaultApp.getActiveFileInfo();
+  const indent = args.prettyPrint ? 2 : undefined;
+
+  // Default include_content to true; frontmatter_only still reads content to parse it
+  const wantContent = args.frontmatter_only ? true : (args.include_content ?? true);
+
+  let content: string | undefined;
+  if (wantContent) {
+    content = await vaultApp.readActiveFileContent();
+  }
+
+  const response: Record<string, unknown> = { ...info };
+
+  if (args.frontmatter_only && content != null) {
+    const parsed = frontmatterHandler.parse(content);
+    response.fm = parsed.frontmatter;
+    // No content field — that's the point of frontmatter_only
+  } else if (args.parse_frontmatter && content != null) {
+    const parsed = frontmatterHandler.parse(content);
+    response.fm = parsed.frontmatter;
+    response.content = parsed.content;
+  } else if (content != null) {
+    response.content = content;
+  }
+
+  return {
+    content: [{ type: "text", text: JSON.stringify(response, null, indent) }],
+  };
+}
+
+export async function handleActiveFolder(
+  vaultApp: VaultAppProvider,
+  fileSystem: FileSystemService,
+  args: {
+    include_files?: boolean;
+    prettyPrint?: boolean;
+  },
+): Promise<ToolResponse> {
+  await vaultApp.ensureRunning();
+
+  const info = await vaultApp.getActiveFileInfo();
+  const filePath = info.path as string;
+  const indent = args.prettyPrint ? 2 : undefined;
+
+  // dirname returns "." for root-level files — correct vault-relative behavior
+  const folder = dirname(filePath);
+
+  const response: Record<string, unknown> = {
+    dir: folder,
+    active: filePath,
+  };
+
+  if (args.include_files ?? true) {
+    const listing = await fileSystem.listDirectory(folder);
+    response.files = listing.files;
+  }
+
+  return {
+    content: [{ type: "text", text: JSON.stringify(response, null, indent) }],
+  };
+}
+
+export async function handleOpen(
+  vaultApp: VaultAppProvider,
+  args: {
+    path: string;
+    newtab?: boolean;
+    prettyPrint?: boolean;
+  },
+): Promise<ToolResponse> {
+  await vaultApp.ensureRunning();
+
+  const path = args.path;
+  if (!path || path.trim() === "") {
+    throw new Error("path is required");
+  }
+
+  const newtab = args.newtab ?? true;
+  await vaultApp.openFile(path, { newtab });
+
+  const indent = args.prettyPrint ? 2 : undefined;
+  return {
+    content: [{ type: "text", text: JSON.stringify({ opened: path, newtab }, null, indent) }],
+  };
+}

--- a/src/createServer.test.ts
+++ b/src/createServer.test.ts
@@ -26,7 +26,7 @@ test("createServer returns a Server instance", () => {
   expect(typeof server.connect).toBe("function");
 });
 
-test("server registers 14 tools", async () => {
+test("server registers 17 tools", async () => {
   const server = createServer(testVaultPath, { version: "1.0.0" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
@@ -38,10 +38,12 @@ test("server registers 14 tools", async () => {
   ]);
 
   const result = await client.listTools();
-  expect(result.tools).toHaveLength(14);
+  expect(result.tools).toHaveLength(17);
 
   const toolNames = result.tools.map((t) => t.name).sort();
   expect(toolNames).toEqual([
+    "active_file",
+    "active_folder",
     "delete_note",
     "get_frontmatter",
     "get_notes_info",
@@ -50,6 +52,7 @@ test("server registers 14 tools", async () => {
     "manage_tags",
     "move_file",
     "move_note",
+    "open",
     "patch_note",
     "read_multiple_notes",
     "read_note",

--- a/src/createServer.ts
+++ b/src/createServer.ts
@@ -7,6 +7,10 @@ import { FileSystemService } from "./filesystem.js";
 import { FrontmatterHandler, parseFrontmatter } from "./frontmatter.js";
 import { PathFilter } from "./pathfilter.js";
 import { SearchService } from "./search.js";
+import { handleActiveFile, handleActiveFolder, handleOpen } from "./active.js";
+import { ObsidianCliVaultAppProvider } from "./obsidian-cli-vault-app-provider.js";
+import { createPlatformStrategy } from "./platform.js";
+import type { VaultAppProvider } from "./vault-app-provider.js";
 import { resolve } from "path";
 
 export interface CreateServerOptions {
@@ -14,6 +18,7 @@ export interface CreateServerOptions {
   version?: string;
   pathFilter?: PathFilter;
   frontmatterHandler?: FrontmatterHandler;
+  vaultAppProvider?: VaultAppProvider;
 }
 
 export function createServer(vaultPath: string, options: CreateServerOptions = {}): Server {
@@ -22,6 +27,7 @@ export function createServer(vaultPath: string, options: CreateServerOptions = {
     version = "0.0.0",
     pathFilter = new PathFilter(),
     frontmatterHandler = new FrontmatterHandler(),
+    vaultAppProvider = new ObsidianCliVaultAppProvider(resolve(vaultPath), createPlatformStrategy()),
   } = options;
 
   const resolvedVaultPath = resolve(vaultPath);
@@ -216,6 +222,43 @@ export function createServer(vaultPath: string, options: CreateServerOptions = {
               prettyPrint: { type: "boolean", description: "Format JSON response with indentation (default: false)", default: false }
             }
           }
+        },
+        {
+          name: "active_file",
+          description: "Return metadata and optionally content of the currently active file in Obsidian. Works with any file type. Requires Obsidian v1.12+ with CLI enabled and a file open.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              include_content: { type: "boolean", description: "Include file content in response (default: true)", default: true },
+              parse_frontmatter: { type: "boolean", description: "Return parsed frontmatter and content separately instead of raw text", default: false },
+              frontmatter_only: { type: "boolean", description: "Return only parsed frontmatter, no content. Mutually exclusive with parse_frontmatter.", default: false },
+              prettyPrint: { type: "boolean", description: "Format JSON response with indentation (default: false)", default: false }
+            }
+          }
+        },
+        {
+          name: "active_folder",
+          description: "Return the folder path of the currently active file in Obsidian, optionally with sibling file listing. Requires Obsidian v1.12+ with CLI enabled.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              include_files: { type: "boolean", description: "Include list of files in the folder (default: true)", default: true },
+              prettyPrint: { type: "boolean", description: "Format JSON response with indentation (default: false)", default: false }
+            }
+          }
+        },
+        {
+          name: "open",
+          description: "Open a file in Obsidian by vault-relative path. Defaults to a new tab. Requires Obsidian v1.12+ with CLI enabled.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              path: { type: "string", description: "Vault-relative path to the file to open (e.g., 'Notes/example.md')" },
+              newtab: { type: "boolean", description: "Open in a new tab (default: true). Set to false to reuse the current tab.", default: true },
+              prettyPrint: { type: "boolean", description: "Format JSON response with indentation (default: false)", default: false }
+            },
+            required: ["path"]
+          }
         }
       ]
     };
@@ -383,6 +426,15 @@ export function createServer(vaultPath: string, options: CreateServerOptions = {
             content: [{ type: "text", text: JSON.stringify({ notes: stats.totalNotes, folders: stats.totalFolders, size: stats.totalSize, recent: stats.recentlyModified }, null, indent) }]
           };
         }
+
+        case "active_file":
+          return await handleActiveFile(vaultAppProvider, frontmatterHandler, trimmedArgs);
+
+        case "active_folder":
+          return await handleActiveFolder(vaultAppProvider, fileSystem, trimmedArgs);
+
+        case "open":
+          return await handleOpen(vaultAppProvider, trimmedArgs);
 
         default:
           throw new Error(`Unknown tool: ${toolName}`);

--- a/src/createServer.ts
+++ b/src/createServer.ts
@@ -225,7 +225,7 @@ export function createServer(vaultPath: string, options: CreateServerOptions = {
         },
         {
           name: "active_file",
-          description: "Return metadata and optionally content of the currently active file in Obsidian. Works with any file type. Requires Obsidian v1.12+ with CLI enabled and a file open.",
+          description: "Return metadata and optionally content of the currently active (focused) file. Works with any file type. Requires a running vault application with a file open.",
           inputSchema: {
             type: "object",
             properties: {
@@ -238,7 +238,7 @@ export function createServer(vaultPath: string, options: CreateServerOptions = {
         },
         {
           name: "active_folder",
-          description: "Return the folder path of the currently active file in Obsidian, optionally with sibling file listing. Requires Obsidian v1.12+ with CLI enabled.",
+          description: "Return the folder path of the currently active file, optionally with sibling file listing. Requires a running vault application with a file open.",
           inputSchema: {
             type: "object",
             properties: {
@@ -249,7 +249,7 @@ export function createServer(vaultPath: string, options: CreateServerOptions = {
         },
         {
           name: "open",
-          description: "Open a file in Obsidian by vault-relative path. Defaults to a new tab. Requires Obsidian v1.12+ with CLI enabled.",
+          description: "Open a file in the vault application by vault-relative path. Defaults to a new tab. Requires a running vault application.",
           inputSchema: {
             type: "object",
             properties: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,8 @@ export { FileSystemService } from './filesystem.js';
 export { FrontmatterHandler, parseFrontmatter } from './frontmatter.js';
 export { PathFilter } from './pathfilter.js';
 export { SearchService } from './search.js';
+export { ObsidianCliVaultAppProvider } from './obsidian-cli-vault-app-provider.js';
+export { createPlatformStrategy } from './platform.js';
+export type { VaultAppProvider } from './vault-app-provider.js';
+export type { PlatformStrategy } from './platform.js';
 export * from './types.js';

--- a/src/obsidian-cli-vault-app-provider.ts
+++ b/src/obsidian-cli-vault-app-provider.ts
@@ -1,0 +1,182 @@
+import { execFile, execFileSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { basename, isAbsolute } from "node:path";
+import { promisify } from "node:util";
+import type { PlatformStrategy } from "./platform.js";
+import type { VaultAppProvider } from "./vault-app-provider.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export type CliExecutor = (command: string, args: string[]) => Promise<ExecResult>;
+
+const DEFAULT_TIMEOUT = 30_000;
+const CHECK_TTL_MS = 15_000;
+
+export class ObsidianCliVaultAppProvider implements VaultAppProvider {
+  private readonly vaultRoot: string;
+  private readonly platform: PlatformStrategy;
+  private readonly vaultName: string;
+  private readonly executor: CliExecutor;
+  private readonly hasCustomExecutor: boolean;
+
+  private cachedCliBin: string | null = null;
+  private runningCache: { alive: boolean; ts: number } | null = null;
+
+  constructor(
+    vaultRoot: string,
+    platform: PlatformStrategy,
+    executor?: CliExecutor,
+  ) {
+    this.vaultRoot = vaultRoot;
+    this.platform = platform;
+    this.vaultName = process.env.OBSIDIAN_VAULT_NAME || basename(vaultRoot);
+    this.hasCustomExecutor = executor != null;
+
+    this.executor = executor ?? (async (command, args) => {
+      const { stdout, stderr } = await execFileAsync(command, args, {
+        timeout: DEFAULT_TIMEOUT,
+        cwd: this.vaultRoot,
+        env: process.env,
+      });
+      return { stdout, stderr, exitCode: 0 };
+    });
+  }
+
+  async getActiveFileInfo(): Promise<Record<string, string | number>> {
+    const result = await this.execCli("file", []);
+    const trimmed = result.stdout.trim();
+    if (!trimmed) {
+      throw new Error("No active file. Open a file in Obsidian and retry.");
+    }
+    return this.parseFileInfo(trimmed);
+  }
+
+  async readActiveFileContent(): Promise<string> {
+    const result = await this.execCli("read", []);
+    return result.stdout;
+  }
+
+  async isRunning(): Promise<boolean> {
+    if (this.runningCache && Date.now() - this.runningCache.ts < CHECK_TTL_MS) {
+      return this.runningCache.alive;
+    }
+
+    const alive = await this.platform.isProcessRunning("Obsidian");
+    this.runningCache = { alive, ts: Date.now() };
+    return alive;
+  }
+
+  async ensureRunning(): Promise<void> {
+    const running = await this.isRunning();
+    if (!running) {
+      throw new Error("Obsidian is not running. Start Obsidian and retry.");
+    }
+  }
+
+  async openFile(path: string, options?: { newtab?: boolean }): Promise<string> {
+    const cliArgs = [`path=${path}`];
+    if (options?.newtab) cliArgs.push("newtab");
+    const result = await this.execCli("open", cliArgs);
+    return result.stdout;
+  }
+
+  private resolveCliBin(): string {
+    if (this.cachedCliBin) return this.cachedCliBin;
+
+    const candidates = this.platform.getCliCandidates();
+
+    // When a custom executor is injected (tests), skip filesystem
+    // validation — the executor replaces the real binary call.
+    if (this.hasCustomExecutor && candidates.length > 0) {
+      this.cachedCliBin = candidates[0]!;
+      return candidates[0]!;
+    }
+
+    for (const candidate of candidates) {
+      try {
+        if (isAbsolute(candidate)) {
+          if (existsSync(candidate) && statSync(candidate).mode & 0o111) {
+            this.cachedCliBin = candidate;
+            return candidate;
+          }
+          continue;
+        }
+        const resolved = execFileSync("which", [candidate], {
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+        }).trim();
+        if (resolved) {
+          this.cachedCliBin = resolved;
+          return resolved;
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    throw new Error(
+      `Obsidian CLI not found. Searched: ${candidates.join(", ")}. Install the Obsidian CLI or add it to PATH.`,
+    );
+  }
+
+  private async execCli(command: string, args: string[]): Promise<ExecResult> {
+    this.platform.ensureEnvironment();
+    const bin = this.resolveCliBin();
+    const cliArgs = [`vault=${this.vaultName}`, command, ...args];
+
+    let result: ExecResult;
+    try {
+      result = await this.executor(bin, cliArgs);
+    } catch (error: unknown) {
+      const err = error as {
+        code?: string;
+        killed?: boolean;
+        stdout?: string;
+        stderr?: string;
+      };
+
+      if (err.killed || err.code === "ETIMEDOUT") {
+        this.runningCache = null;
+        throw new Error(
+          `Obsidian CLI timed out after ${DEFAULT_TIMEOUT}ms for command: ${command}`,
+        );
+      }
+
+      throw new Error(
+        err.stderr?.trim() || err.stdout?.trim() || String(error),
+      );
+    }
+
+    // The Obsidian CLI reports some errors via stdout (exit code 0)
+    if (result.stdout.startsWith("Error:")) {
+      throw new Error(result.stdout.slice(7).trim());
+    }
+    if (result.stdout.startsWith("Command line interface is not enabled")) {
+      throw new Error(
+        "Obsidian CLI is not enabled. Turn it on in Obsidian → Settings → General → Advanced.",
+      );
+    }
+
+    return result;
+  }
+
+  /** Parse tab-separated key\tvalue lines from CLI `file` output. */
+  private parseFileInfo(output: string): Record<string, string | number> {
+    const result: Record<string, string | number> = {};
+    for (const line of output.split("\n")) {
+      const sep = line.indexOf("\t");
+      if (sep === -1) continue;
+      const key = line.slice(0, sep).trim();
+      const val = line.slice(sep + 1).trim();
+      const num = Number(val);
+      result[key] = Number.isFinite(num) && /^\d+$/.test(val) ? num : val;
+    }
+    return result;
+  }
+}

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,0 +1,104 @@
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Platform-specific strategy for resolving CLI binaries and detecting processes.
+ * Consumed internally by CLI-based VaultAppProvider implementations.
+ */
+export interface PlatformStrategy {
+  /** Candidate paths for the CLI binary, checked in order. */
+  getCliCandidates(): string[];
+
+  /** Check if the application process is running. */
+  isProcessRunning(processName: string): Promise<boolean>;
+
+  /** Apply platform-specific environment fixups (e.g., TMPDIR on macOS). */
+  ensureEnvironment(): void;
+}
+
+export function createPlatformStrategy(): PlatformStrategy {
+  switch (process.platform) {
+    case "darwin": return new DarwinPlatformStrategy();
+    case "linux":  return new LinuxPlatformStrategy();
+    case "win32":  return new WindowsPlatformStrategy();
+    default:       return new LinuxPlatformStrategy();
+  }
+}
+
+class DarwinPlatformStrategy implements PlatformStrategy {
+  getCliCandidates(): string[] {
+    return [
+      "obsidian",
+      "/Applications/Obsidian.app/Contents/MacOS/obsidian",
+    ];
+  }
+
+  async isProcessRunning(processName: string): Promise<boolean> {
+    try {
+      await execFileAsync("pgrep", ["-xiq", processName]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  ensureEnvironment(): void {
+    if (process.env.TMPDIR) return;
+    try {
+      const darwinTemp = execFileSync("getconf", ["DARWIN_USER_TEMP_DIR"], {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim();
+      if (darwinTemp) {
+        process.env.TMPDIR = darwinTemp;
+        return;
+      }
+    } catch {
+      // fall through
+    }
+    process.env.TMPDIR = "/tmp";
+  }
+}
+
+class LinuxPlatformStrategy implements PlatformStrategy {
+  getCliCandidates(): string[] {
+    return ["obsidian"];
+  }
+
+  async isProcessRunning(processName: string): Promise<boolean> {
+    try {
+      await execFileAsync("pgrep", ["-xi", processName]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  ensureEnvironment(): void {
+    // no-op on Linux
+  }
+}
+
+class WindowsPlatformStrategy implements PlatformStrategy {
+  getCliCandidates(): string[] {
+    return ["obsidian.exe"];
+  }
+
+  async isProcessRunning(processName: string): Promise<boolean> {
+    try {
+      const { stdout } = await execFileAsync("tasklist", [
+        "/FI", `IMAGENAME eq ${processName}.exe`,
+        "/NH",
+      ]);
+      return stdout.toLowerCase().includes(processName.toLowerCase());
+    } catch {
+      return false;
+    }
+  }
+
+  ensureEnvironment(): void {
+    // no-op on Windows
+  }
+}

--- a/src/vault-app-provider.ts
+++ b/src/vault-app-provider.ts
@@ -1,0 +1,23 @@
+/**
+ * Behavioral interface for communicating with a running vault application.
+ * Tools depend on this interface — never on a specific app or transport.
+ */
+export interface VaultAppProvider {
+  /** Get metadata about the currently active/focused file. */
+  getActiveFileInfo(): Promise<Record<string, string | number>>;
+
+  /** Read the content of the currently active/focused file. */
+  readActiveFileContent(): Promise<string>;
+
+  /** Check if the vault application is running and reachable. */
+  isRunning(): Promise<boolean>;
+
+  /**
+   * Ensure the app is running; throw a descriptive error if not.
+   * Implementations may cache the result with a short TTL.
+   */
+  ensureRunning(): Promise<void>;
+
+  /** Open a file in the vault app by vault-relative path. */
+  openFile(path: string, options?: { newtab?: boolean }): Promise<string>;
+}


### PR DESCRIPTION
## Summary

- Add three tools that depend on the Obsidian CLI (v1.12+) to query running app state: `active_file`, `active_folder`, and `open`
- Introduce `VaultAppProvider` interface (5 methods) with `ObsidianCliVaultAppProvider` implementation and `PlatformStrategy` abstraction (Darwin/Linux/Windows)
- Server starts and serves all existing tools even when Obsidian is not installed — CLI resolution is lazy (first tool call, not startup)

Closes #69

## Architecture

```
Tools (active_file, active_folder, open)
  │  depend on
  ▼
VaultAppProvider (interface)              ← app-agnostic behavioral contract
  │  implemented by
  ▼
ObsidianCliVaultAppProvider (class)       ← shells out to Obsidian CLI
  │  uses internally
  ▼
PlatformStrategy (interface)              ← binary resolution + process detection
  ├── DarwinPlatformStrategy
  ├── LinuxPlatformStrategy
  └── WindowsPlatformStrategy
```

## Test plan

- [ ] 21 mock tests pass without Obsidian (CI-ready, Node 20-24)
- [ ] `npm run build` compiles cleanly
- [ ] Existing 167 tests unaffected
- [ ] Manual test with Obsidian v1.12+ running: call `active_file`, `active_folder`, `open`