### PR TITLE
feat: update Obsidian CLI preflight for 1.12.7+ installer

### DIFF
--- a/skills/obsidian/SKILL.md
+++ b/skills/obsidian/SKILL.md
@@ -97,7 +97,44 @@ When the user asks to "sync", "backup", or "store my vault with git", use CLI gi
 When the user asks for app-context operations (active file, open in editor, daily notes with templates, backlinks), use the Obsidian CLI directly via shell commands.
 
 1. Run a **preflight** before first CLI use:
-   - Check binary exists: `/Applications/Obsidian.app/Contents/MacOS/obsidian` (macOS), `obsidian` (Linux), `obsidian.exe` (Windows)
+   - Resolve the CLI binary using the first match from these candidates:
+
+     | Priority | macOS | Linux | Windows |
+     |----------|-------|-------|---------|
+     | 1 | `obsidian` (PATH) | `obsidian` (PATH) | `obsidian.exe` or `Obsidian.com` (PATH) |
+     | 2 | `/Applications/Obsidian.app/Contents/MacOS/obsidian-cli` | — | — |
+     | 3 | `/Applications/Obsidian.app/Contents/MacOS/Obsidian` | — | — |
+
+     > **Obsidian 1.12.7+ installer** bundles a dedicated `obsidian-cli` binary (~10x
+     > faster than the legacy Electron-based CLI: ~25ms vs ~250ms per call). On macOS,
+     > after installing the 1.12.7+ installer, disable then re-enable the CLI in
+     > Settings > General > Advanced to update PATH registration. This replaces the old
+     > `~/.zprofile` PATH entry with a `/usr/local/bin/obsidian` symlink pointing to
+     > `obsidian-cli`.
+     >
+     > On Linux, PATH registration creates a symlink at `/usr/local/bin/obsidian`
+     > (or `~/.local/bin/obsidian` as fallback). On Windows, the installer places an
+     > `Obsidian.com` terminal redirector alongside `Obsidian.exe`.
+     >
+     > **Note:** The priority table and stale PATH check are verified on macOS only.
+     > Linux and Windows may also bundle `obsidian-cli` with the 1.12.7+ installer,
+     > but this has not been confirmed. Contributions welcome via issue or PR.
+
+   - **Stale PATH check (macOS):** If priority 1 resolved `obsidian` on PATH, check
+     whether it points to the fast binary or the slow Electron launcher:
+
+     | Resolved path | Meaning | Action |
+     |---------------|---------|--------|
+     | `/usr/local/bin/obsidian` → `obsidian-cli` | 1.12.7 symlink registration | None — fast binary |
+     | `/Applications/.../MacOS/obsidian` | Old `~/.zprofile` entry (pre-1.12.7 registration or 1.12.7 installer without re-registering) | Check if `obsidian-cli` exists in the bundle |
+
+     If `obsidian` resolves to the MacOS directory (not `/usr/local/bin`) AND
+     `/Applications/Obsidian.app/Contents/MacOS/obsidian-cli` exists, tell the user:
+     _"Obsidian 1.12.7+ is installed but PATH still points to the slower Electron
+     binary. In Obsidian, go to Settings > General > Advanced and disable then
+     re-enable the CLI to update PATH registration."_
+     Continue with whichever priority matched — this is advisory, not blocking.
+
    - Check Obsidian is running: `pgrep -xiq obsidian` (macOS/Linux) or `tasklist /FI "IMAGENAME eq Obsidian.exe" /NH` (Windows)
    - If either fails, tell the user and fall back to MCP tools + `obsidian://` URIs
 


### PR DESCRIPTION
## Summary

- Replace the single hardcoded binary check in the Obsidian CLI skill with a cascading priority table and stale PATH detection
- Obsidian 1.12.7+ installer bundles a dedicated `obsidian-cli` binary (~10x faster: ~25ms vs ~250ms per call)
- The 1.12.7 installer changes the macOS PATH registration mechanism from a `~/.zprofile` entry to a `/usr/local/bin/obsidian` symlink pointing to `obsidian-cli`
- Includes Linux and Windows registration details from the [official Obsidian CLI docs](https://obsidian.md/help/cli#Troubleshooting)

## Testing methodology

Performed a full clean-room walkthrough on macOS (Darwin 25.3.0, ARM64):

1. **Clean uninstall** — deleted `/Applications/Obsidian.app`, `~/Library/Application Support/obsidian/`, all PATH entries and symlinks
2. **Fresh 1.12.4 install** — disabled auto-update, deleted auto-downloaded `obsidian-1.12.7.asar` to ensure true 1.12.4 app code
3. **Captured 5 states sequentially**, checking at each step: `which obsidian`, `which obsidian-cli`, `/usr/local/bin/obsidian` symlink, `~/.zprofile` contents, app bundle contents, `obsidian.json` config, and CLI responsiveness
4. All PATH-dependent checks used fresh login shells (`/bin/zsh -l -c`) to avoid stale environment

## Verified behavior (macOS)

| State | `which obsidian` | `obsidian-cli` in bundle | PATH mechanism | CLI speed |
|---|---|---|---|---|
| 1.12.4, CLI disabled | not found | no | — | "not enabled" |
| 1.12.4, CLI enabled, no PATH | not found | no | none | absolute path only (~250ms) |
| 1.12.4, CLI enabled, PATH registered | `.../MacOS/obsidian` | no | `~/.zprofile` adds MacOS dir | ~250ms (Electron) |
| 1.12.7 installer over 1.12.4, no CLI toggle | `.../MacOS/obsidian` | **yes** | inherited zprofile | both binaries available |
| 1.12.7, CLI re-registered | `/usr/local/bin/obsidian` → `obsidian-cli` | **yes** | symlink (replaces zprofile) | ~25ms |

Key findings:
- The `obsidian-cli` binary is **only added by the 1.12.7+ installer** — the app auto-update alone does not add it
- 1.12.7 PATH re-registration **removes the old `~/.zprofile` entry** and replaces it with a `/usr/local/bin/obsidian` symlink to `obsidian-cli`
- `obsidian-cli` is almost never directly on PATH — the symlink is named `obsidian`, so that is the correct priority 1 check
- The stale PATH signal is: `which obsidian` resolves to the MacOS directory (not `/usr/local/bin`) while `obsidian-cli` exists in the bundle

## Notes

- Backward-compatible: the priority table falls through to the Electron binary on pre-1.12.7 installs
- Linux/Windows PATH registration details are from the [official docs](https://obsidian.md/help/cli#Troubleshooting), not independently verified
- The stale PATH check is advisory only — it never blocks CLI usage

Closes #92